### PR TITLE
feat: refactor job worker architecture and improve logging in job execution

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,6 @@ POSTGRES_DB=planifetsDB
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/planifetsDB?schema=public" # local dev
 
 # Optional
-LOG_LEVELS="log,error,warn,debug,verbose" # Log levels: "log,error,warn,debug,fatal,verbose"
+LOG_LEVELS="log,error,warn" # Log levels: "log,error,warn,debug,fatal,verbose"
 SENTRY_AUTH_TOKEN=
 SENTRY_DSN=""

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,2 +1,2 @@
 sonar.cpd.exclusions=test/**
-sonar.exclusions=test/assets/**
+sonar.exclusions=test/**,test/assets/**

--- a/docs/jobs/jobs-pipeline.md
+++ b/docs/jobs/jobs-pipeline.md
@@ -13,6 +13,8 @@ This pipeline keeps PlanifETS academic data in sync with external ETS sources. T
 - The pipeline is coordinated by `JobsService`.
 - Jobs run sequentially in a fixed order.
 - Each job spawns its own short-lived worker thread through `jobRunner.worker.ts`.
+- Workers bootstrap `JobsModule` directly.
+- Scheduler registration stays in `JobsSchedulerModule`, which is only imported by the main app.
 - A failure is logged, but the pipeline continues with the next job.
 
 ## Current order
@@ -73,7 +75,7 @@ sequenceDiagram
 
     loop Each selected job
         Jobs->>Worker: spawn(serviceName, methodName)
-        Worker->>App: createApplicationContext(AppModule)
+        Worker->>App: createApplicationContext(JobsModule)
         Worker->>Service: resolve mapped service + method
         Service->>Sources: fetch / parse data
         Service->>DB: create / update records
@@ -82,5 +84,7 @@ sequenceDiagram
         Jobs->>Jobs: log result and continue
     end
 
-    Note right of Worker: One worker thread is spawned per job. The worker mapping currently exposes Programs, Courses, CourseInstances, and Sessions job services.
+    Note right of Worker: One worker thread is spawned per job and exits when that job finishes. JobsModule is worker-safe because schedule registration lives in JobsSchedulerModule, not in the worker bootstrap path.
 ```
+
+Note that the current implementation uses one short-lived worker per job.

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,8 +9,7 @@ import { EtsModule } from './common/api-helper/ets/ets.module';
 import { PdfModule } from './common/website-helper/pdf/pdf.module';
 import { CourseModule } from './course/course.module';
 import { CourseInstanceModule } from './course-instance/course-instance.module';
-import { JobsModule } from './jobs/jobs.module';
-import { JobsService } from './jobs/jobs.service';
+import { JobsSchedulerModule } from './jobs/jobs-scheduler.module';
 import { PrerequisiteModule } from './prerequisite/prerequisite.module';
 import { PrismaModule } from './prisma/prisma.module';
 import { ProgramModule } from './program/program.module';
@@ -24,7 +23,7 @@ import { SessionModule } from './session/session.module';
     CheminotModule,
     EtsModule,
     PdfModule,
-    JobsModule,
+    JobsSchedulerModule,
 
     // CRUD modules
     CourseModule,
@@ -41,9 +40,8 @@ import { SessionModule } from './session/session.module';
       provide: APP_FILTER,
       useClass: SentryGlobalFilter,
     },
-    JobsService
   ],
   controllers: [AppController],
-  exports: [HttpModule, JobsService],
+  exports: [HttpModule],
 })
-export class AppModule { }
+export class AppModule {}

--- a/src/common/logger/app-logger-factory.ts
+++ b/src/common/logger/app-logger-factory.ts
@@ -1,0 +1,15 @@
+import { LogLevel } from '@nestjs/common';
+
+import { SentryLogger } from '@/common/logger/sentry.logger';
+
+function resolveLogLevels(): LogLevel[] {
+  return process.env.LOG_LEVELS
+    ? (process.env.LOG_LEVELS.split(',') as LogLevel[])
+    : ['error', 'warn', 'log'];
+}
+
+export function createAppLoggerFactory(context?: string): SentryLogger {
+  const logger = new SentryLogger(context ?? 'Application');
+  logger.setLogLevels(resolveLogLevels());
+  return logger;
+}

--- a/src/common/logger/sentry.logger.ts
+++ b/src/common/logger/sentry.logger.ts
@@ -1,7 +1,7 @@
 import { ConsoleLogger, Injectable } from '@nestjs/common';
 import * as Sentry from '@sentry/nestjs';
 
-import { formatMessage } from '../utils/stringUtil';
+import { formatMessage } from '@/common/utils/stringUtil';
 
 @Injectable()
 export class SentryLogger extends ConsoleLogger {

--- a/src/jobs/dtos/run-workers.dto.ts
+++ b/src/jobs/dtos/run-workers.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-
+// Used in development environment only
 export class RunWorkersDto {
   @ApiProperty({ default: true })
   public processAllJobs: boolean = true;

--- a/src/jobs/jobs-scheduler.module.ts
+++ b/src/jobs/jobs-scheduler.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { ScheduleModule } from '@nestjs/schedule';
+
+import { JobsModule } from './jobs.module';
+
+// Keep scheduler registration out of JobsModule because 
+// workers bootstrap JobsModule directly and should not initialize @Cron/@Timeout handlers.
+@Module({
+  imports: [
+    ScheduleModule.forRoot(),
+    JobsModule,
+  ],
+})
+export class JobsSchedulerModule {}

--- a/src/jobs/jobs.constants.ts
+++ b/src/jobs/jobs.constants.ts
@@ -1,0 +1,26 @@
+import { Provider } from '@nestjs/common';
+
+import { CourseCodeValidationPipe } from '../common/pipes/models/course/course-code-validation-pipe';
+import { CourseInstancesJobService } from './workers/course-instances.worker';
+import { CoursesJobService } from './workers/courses.worker';
+import { ProgramsJobService } from './workers/programs.worker';
+import { SessionsJobService } from './workers/sessions.worker';
+
+export const jobWorkerServiceMap = {
+  ProgramsJobService,
+  CoursesJobService,
+  CourseInstancesJobService,
+  SessionsJobService,
+} as const;
+
+export const jobWorkerProviders: Provider[] = [
+  ...Object.values(jobWorkerServiceMap),
+  CourseCodeValidationPipe,
+];
+
+export type JobWorkerServiceName = keyof typeof jobWorkerServiceMap;
+
+export interface JobWorkerData {
+  serviceName: JobWorkerServiceName;
+  methodName: string;
+}

--- a/src/jobs/jobs.module.ts
+++ b/src/jobs/jobs.module.ts
@@ -1,9 +1,7 @@
 import { Module } from '@nestjs/common';
-import { ScheduleModule } from '@nestjs/schedule';
 
 import { CheminotModule } from '../common/api-helper/cheminot/cheminot.module';
 import { EtsModule } from '../common/api-helper/ets/ets.module';
-import { CourseCodeValidationPipe } from '../common/pipes/models/course/course-code-validation-pipe';
 import { PdfModule } from '../common/website-helper/pdf/pdf.module';
 import { CourseModule } from '../course/course.module';
 import { CourseInstanceModule } from '../course-instance/course-instance.module';
@@ -11,16 +9,12 @@ import { PrerequisiteModule } from '../prerequisite/prerequisite.module';
 import { ProgramModule } from '../program/program.module';
 import { ProgramCourseModule } from '../program-course/program-course.module';
 import { SessionModule } from '../session/session.module';
+import { jobWorkerProviders } from './jobs.constants';
 import { JobsController } from './jobs.controller';
 import { JobsService } from './jobs.service';
-import { CourseInstancesJobService } from './workers/course-instances.worker';
-import { CoursesJobService } from './workers/courses.worker';
-import { ProgramsJobService } from './workers/programs.worker';
-import { SessionsJobService } from './workers/sessions.worker';
 
 @Module({
   imports: [
-    ScheduleModule.forRoot(),
     CourseModule,
     CourseInstanceModule,
     PrerequisiteModule,
@@ -34,13 +28,9 @@ import { SessionsJobService } from './workers/sessions.worker';
   ],
   providers: [
     JobsService,
-    CoursesJobService,
-    CourseInstancesJobService,
-    ProgramsJobService,
-    SessionsJobService,
-
-    CourseCodeValidationPipe,
+    ...jobWorkerProviders,
   ],
   controllers: process.env.APP_ENV === 'development' ? [JobsController] : [], // Only expose in dev mode for running jobs manually
+  exports: [JobsService],
 })
-export class JobsModule { }
+export class JobsModule {}

--- a/src/jobs/jobs.service.ts
+++ b/src/jobs/jobs.service.ts
@@ -8,17 +8,13 @@ import { Cron, CronExpression, Timeout } from '@nestjs/schedule';
 export class JobsService {
   private readonly logger = new Logger(JobsService.name);
 
-  private checkMainThread() {
-    this.logger.debug(
-      'Are we on the main thread?',
-      isMainThread ? 'Yes' : 'No',
-    );
-  }
-
   public runWorker<T>(serviceName: string, methodName: string): Promise<T> {
     return new Promise<T>((resolve, reject) => {
       const workerScript = join(__dirname, 'workers', 'jobRunner.worker.js');
       const workerData = { serviceName, methodName };
+
+      this.logger.log(`Spawning worker for ${serviceName}.${methodName}`);
+
       const worker = new Worker(workerScript, { workerData });
 
       worker.on('message', (message) => {
@@ -43,7 +39,7 @@ export class JobsService {
     });
   }
 
-  @Timeout(30_000) // run 30 seconds after boot
+  @Timeout(600_000) // run 10 minutes after boot
   public async runOnceAfterBoot() {
     if (process.env.APP_ENV !== 'production') {
       return;
@@ -56,7 +52,7 @@ export class JobsService {
   @Cron(CronExpression.EVERY_1ST_DAY_OF_MONTH_AT_MIDNIGHT, { timeZone: 'America/Toronto' })
   public async processJobs(): Promise<void> {
     this.logger.log('Starting sequential job processing...');
-    this.checkMainThread();
+    this.logger.debug('Are we on the main thread?', isMainThread ? 'Yes' : 'No');
 
     const jobs = [
       // Creates and updates Programs and ProgramTypes entities.
@@ -100,7 +96,7 @@ export class JobsService {
       try {
         const result = await this.runWorker(service, method);
         this.logger.log(
-          `Job ${index + 1} (${service}.${method}) completed successfully: ${JSON.stringify(result)}`,
+          `Job ${index + 1} (${service}.${method}) completed : ${JSON.stringify(result)}`,
         );
       } catch (error) {
         if (error instanceof Error) {

--- a/src/jobs/workers/jobRunner.worker.ts
+++ b/src/jobs/workers/jobRunner.worker.ts
@@ -1,6 +1,5 @@
 import '../../instrument';
 
-import { Logger } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { isMainThread, parentPort, workerData } from 'worker_threads';
 
@@ -13,31 +12,32 @@ interface ServiceInstance {
   [key: string]: () => Promise<void>;
 }
 
-(async () => {
-  const logger = new Logger('JobRunnerWorker');
-  logger.debug('Are we on the main thread?', isMainThread ? 'Yes' : 'No');
-
-  const { serviceName, methodName } = workerData as JobWorkerData;
+async function runJobWorker(
+  serviceName: JobWorkerData['serviceName'],
+  methodName: JobWorkerData['methodName'],
+) {
   const appContext = await NestFactory.createApplicationContext(
     JobsModule,
     {
       logger: false, // this suppresses the default Nest logger since we'll use our custom logger instead
     },
   );
-  appContext.useLogger(createAppLoggerFactory('JobWorkerNestContext'));
 
   try {
-    // Get the Service Class from the mapping
+    appContext.useLogger(createAppLoggerFactory('JobWorkerNestContext'));
+
     const ServiceClass = jobWorkerServiceMap[serviceName];
 
     if (!ServiceClass) {
       throw new Error(`Service ${serviceName} not found in service mapping`);
     }
 
-    // Get the service instance using the class reference
     const serviceInstance = appContext.get(ServiceClass) as ServiceInstance;
 
-    if (!serviceInstance || typeof serviceInstance[methodName] !== 'function') {
+    if (
+      !serviceInstance ||
+      typeof serviceInstance[methodName] !== 'function'
+    ) {
       throw new Error(
         `Method ${methodName} not found on service ${serviceName}`,
       );
@@ -45,12 +45,26 @@ interface ServiceInstance {
 
     // Execute the specified method
     await serviceInstance[methodName]();
-
-    parentPort?.postMessage(`${methodName} completed successfully`);
-
+  } finally {
     await appContext.close();
-    process.exit(0);
+  }
+}
+
+// Worker logic
+(async () => {
+  const logger = createAppLoggerFactory('JobRunnerWorker');
+  logger.debug('Are we on the main thread?', isMainThread ? 'Yes' : 'No');
+
+  const { serviceName, methodName } = workerData as JobWorkerData;
+  let exitCode = 0;
+
+  try {
+    await runJobWorker(serviceName, methodName);
+
+    parentPort?.postMessage(`${methodName} completed.`);
   } catch (error) {
+    exitCode = 1;
+
     if (error instanceof Error) {
       logger.error(`Error in JobRunnerWorker: ${error.message}`, error.stack);
       parentPort?.postMessage(`Error: ${error.message}`);
@@ -58,8 +72,7 @@ interface ServiceInstance {
       logger.error(`Error in JobRunnerWorker: ${error}`);
       parentPort?.postMessage(`Error: ${error}`);
     }
-
-    await appContext?.close();
-    process.exit(1);
   }
+
+  process.exit(exitCode);
 })();

--- a/src/jobs/workers/jobRunner.worker.ts
+++ b/src/jobs/workers/jobRunner.worker.ts
@@ -1,24 +1,13 @@
-import { Logger, LogLevel } from '@nestjs/common';
+import '../../instrument';
+
+import { Logger } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { isMainThread, parentPort, workerData } from 'worker_threads';
 
-import { AppModule } from '../../app.module';
-import { CourseInstancesJobService } from './course-instances.worker';
-import { CoursesJobService } from './courses.worker';
-import { ProgramsJobService } from './programs.worker';
-import { SessionsJobService } from './sessions.worker';
+import { createAppLoggerFactory } from '@/common/logger/app-logger-factory';
 
-const serviceMapping = {
-  ProgramsJobService,
-  CoursesJobService,
-  CourseInstancesJobService,
-  SessionsJobService,
-};
-
-interface WorkerData {
-  serviceName: keyof typeof serviceMapping;
-  methodName: string;
-}
+import { JobWorkerData, jobWorkerServiceMap } from '../jobs.constants';
+import { JobsModule } from '../jobs.module';
 
 interface ServiceInstance {
   [key: string]: () => Promise<void>;
@@ -28,16 +17,18 @@ interface ServiceInstance {
   const logger = new Logger('JobRunnerWorker');
   logger.debug('Are we on the main thread?', isMainThread ? 'Yes' : 'No');
 
-  const { serviceName, methodName } = workerData as WorkerData;
-  const appContext = await NestFactory.createApplicationContext(AppModule, {
-    logger: process.env.LOG_LEVELS
-      ? (process.env.LOG_LEVELS.split(',') as LogLevel[])
-      : ['error', 'warn', 'log'],
-  });
+  const { serviceName, methodName } = workerData as JobWorkerData;
+  const appContext = await NestFactory.createApplicationContext(
+    JobsModule,
+    {
+      logger: false, // this suppresses the default Nest logger since we'll use our custom logger instead
+    },
+  );
+  appContext.useLogger(createAppLoggerFactory('JobWorkerNestContext'));
 
   try {
     // Get the Service Class from the mapping
-    const ServiceClass = serviceMapping[serviceName];
+    const ServiceClass = jobWorkerServiceMap[serviceName];
 
     if (!ServiceClass) {
       throw new Error(`Service ${serviceName} not found in service mapping`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,14 @@
-import "./instrument";
+import './instrument';
 
-import { LogLevel, ValidationPipe } from '@nestjs/common';
+import { ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
+import { HttpExceptionFilter } from '@/common/exceptions/http-exception.filter';
+import { createAppLoggerFactory } from '@/common/logger/app-logger-factory';
+
 import { AppModule } from './app.module';
-import { HttpExceptionFilter } from './common/exceptions/http-exception.filter';
-import { SentryLogger } from "./common/logger/sentry.logger";
+
 
 async function bootstrap() {
   const app = await NestFactory.create(
@@ -26,12 +28,7 @@ async function bootstrap() {
   app.useGlobalFilters(new HttpExceptionFilter());
 
   //Log levels
-  const sentryLogger = new SentryLogger();
-  if (process.env.LOG_LEVELS) {
-    sentryLogger.setLogLevels(process.env.LOG_LEVELS.split(',') as LogLevel[]);
-  }
-  app.useLogger(sentryLogger);
-
+  app.useLogger(createAppLoggerFactory());
 
   //Swagger
   const version = process.env.APP_GIT_SHORT_SHA ? `1.0.0 (${process.env.APP_GIT_SHORT_SHA})` : '1.0.0';

--- a/test/jobs/jobRunner.worker.test.ts
+++ b/test/jobs/jobRunner.worker.test.ts
@@ -1,0 +1,193 @@
+describe('jobRunner.worker', () => {
+  const flushWorker = async () => {
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+  };
+
+  const loadWorker = async ({
+    appContext,
+    createApplicationContextMock,
+    serviceInstance = { run: jest.fn().mockResolvedValue(undefined) },
+    workerData = {
+      serviceName: 'TestService',
+      methodName: 'run',
+    },
+  }: {
+    appContext?: {
+      useLogger: jest.Mock;
+      get: jest.Mock;
+      close: jest.Mock;
+    };
+    createApplicationContextMock?: jest.Mock;
+    serviceInstance?: Record<string, jest.Mock>;
+    workerData?: {
+      serviceName: string;
+      methodName: string;
+    };
+  }) => {
+    jest.resetModules();
+
+    const postMessage = jest.fn();
+    const useLogger = jest.fn();
+    const close = jest.fn().mockResolvedValue(undefined);
+    const get = jest.fn().mockReturnValue(serviceInstance);
+    const loggerErrorSpy = jest.fn();
+    const loggerDebugSpy = jest.fn();
+    const workerLogger = {
+      log: jest.fn(),
+      error: loggerErrorSpy,
+      warn: jest.fn(),
+      debug: loggerDebugSpy,
+    };
+    const nestContextLogger = {
+      log: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    };
+    const createAppLoggerFactory = jest
+      .fn()
+      .mockImplementation((context: string) => (
+        context === 'JobRunnerWorker' ? workerLogger : nestContextLogger
+      ));
+
+    const resolvedAppContext = appContext ?? {
+      useLogger,
+      get,
+      close,
+    };
+    const createApplicationContext = createApplicationContextMock
+      ?? jest.fn().mockResolvedValue(resolvedAppContext);
+
+    const exitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as never);
+
+    class TestService {}
+
+    jest.doMock('../../src/instrument', () => ({}));
+    jest.doMock('@nestjs/core', () => ({
+      NestFactory: {
+        createApplicationContext,
+      },
+    }));
+    jest.doMock('@/common/logger/app-logger-factory', () => ({
+      createAppLoggerFactory,
+    }));
+    jest.doMock('../../src/jobs/jobs.constants', () => ({
+      jobWorkerServiceMap: {
+        TestService,
+      },
+    }));
+    jest.doMock('../../src/jobs/jobs.module', () => ({
+      JobsModule: class JobsModule {},
+    }));
+    jest.doMock('worker_threads', () => ({
+      isMainThread: false,
+      parentPort: {
+        postMessage,
+      },
+      workerData,
+    }));
+
+    await import('../../src/jobs/workers/jobRunner.worker');
+    await flushWorker();
+
+    return {
+      close,
+      createAppLoggerFactory,
+      createApplicationContext,
+      exitSpy,
+      get,
+      loggerDebugSpy,
+      loggerErrorSpy,
+      postMessage,
+      serviceInstance,
+      useLogger,
+    };
+  };
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it('logs, reports, and exits when application context bootstrap fails', async () => {
+    const bootstrapError = new Error('bootstrap failed');
+    const createApplicationContextMock = jest
+      .fn()
+      .mockRejectedValue(bootstrapError);
+
+    const { createApplicationContext, exitSpy, loggerErrorSpy, postMessage } =
+      await loadWorker({ createApplicationContextMock });
+
+    expect(createApplicationContext).toHaveBeenCalledTimes(1);
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      'Error in JobRunnerWorker: bootstrap failed',
+      bootstrapError.stack,
+    );
+    expect(postMessage).toHaveBeenCalledWith('Error: bootstrap failed');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('posts success, closes the context, and exits cleanly when the job completes', async () => {
+    const run = jest.fn().mockResolvedValue(undefined);
+
+    const {
+      close,
+      createAppLoggerFactory,
+      exitSpy,
+      get,
+      postMessage,
+      useLogger,
+    } = await loadWorker({
+      serviceInstance: { run },
+    });
+
+    expect(createAppLoggerFactory).toHaveBeenCalledWith('JobWorkerNestContext');
+    expect(useLogger).toHaveBeenCalledTimes(1);
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith('run completed.');
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it('closes the context and reports job execution failures', async () => {
+    const jobError = new Error('job failed');
+    const run = jest.fn().mockRejectedValue(jobError);
+
+    const { close, exitSpy, loggerErrorSpy, postMessage } = await loadWorker({
+      serviceInstance: { run },
+    });
+
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      'Error in JobRunnerWorker: job failed',
+      jobError.stack,
+    );
+    expect(postMessage).toHaveBeenCalledWith('Error: job failed');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('reports cleanup failures when context shutdown throws', async () => {
+    const closeError = new Error('close failed');
+    const run = jest.fn().mockResolvedValue(undefined);
+
+    const { exitSpy, loggerErrorSpy, postMessage } = await loadWorker({
+      appContext: {
+        useLogger: jest.fn(),
+        get: jest.fn().mockReturnValue({ run }),
+        close: jest.fn().mockRejectedValue(closeError),
+      },
+    });
+
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      'Error in JobRunnerWorker: close failed',
+      closeError.stack,
+    );
+    expect(postMessage).toHaveBeenCalledWith('Error: close failed');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/test/jobs/jobs.service.test.ts
+++ b/test/jobs/jobs.service.test.ts
@@ -66,7 +66,7 @@ describe('JobsService', () => {
     expect(loggerLogSpy).toHaveBeenCalledWith('Starting job 6: SessionsJobService.processSessions');
     expect(loggerLogSpy).toHaveBeenCalledWith('Job processing completed.');
     expect(loggerLogSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Job 1 (ProgramsJobService.processPrograms) completed successfully'),
+      expect.stringContaining('Job 1 (ProgramsJobService.processPrograms) completed :'),
     );
     expect(loggerErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining('Job 2 (CoursesJobService.processCourses) failed: fail2'),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,9 +12,6 @@
     "baseUrl": ".",
     "forceConsistentCasingInFileNames": true,
     "paths": {
-      "*": [
-        "./src/*"
-      ],
       "test/*": [
         "./test/*"
       ],


### PR DESCRIPTION
- Separate scheduler registration from `JobsModule` so worker threads can bootstrap job dependencies without initializing cron handlers.
- Create logger setup in `app-logger-factory.ts` that is reused in job-workers and main.
- Increase job startup to 10min instead of 30sec (safer for blue/green deployments) (quick fix for now, the right way should probably be: add a lock in Postgres to prevent two pipelines running concurrently.)