### PR TITLE
fix: add openssl installation to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ FROM node:22.22.3-alpine3.22 AS base
 
 WORKDIR /app
 COPY package.json yarn.lock ./
-RUN yarn install --frozen-lockfile --ignore-scripts
+RUN apk add --no-cache openssl && \
+    yarn install --frozen-lockfile --ignore-scripts
 
 # Build
 FROM base AS build
@@ -38,7 +39,7 @@ COPY package.json yarn.lock ./
 COPY prisma ./prisma
 # Install dependencies and tzdata
 RUN yarn install --production --frozen-lockfile --ignore-scripts && \
-    apk add --no-cache tzdata && \
+    apk add --no-cache tzdata openssl && \
     cp /usr/share/zoneinfo/${TZ} /etc/localtime && \
     echo "${TZ}" > /etc/timezone
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@
 FROM node:22.22.3-alpine3.22 AS base
 
 WORKDIR /app
+RUN apk add --no-cache openssl
 COPY package.json yarn.lock ./
-RUN apk add --no-cache openssl && \
-    yarn install --frozen-lockfile --ignore-scripts
+RUN yarn install --frozen-lockfile --ignore-scripts
 
 # Build
 FROM base AS build
@@ -35,13 +35,12 @@ ENV APP_ENV=production
 ENV TZ=America/Toronto
 
 WORKDIR /app
-COPY package.json yarn.lock ./
-COPY prisma ./prisma
-# Install dependencies and tzdata
-RUN yarn install --production --frozen-lockfile --ignore-scripts && \
-    apk add --no-cache tzdata openssl && \
+RUN apk add --no-cache tzdata openssl && \
     cp /usr/share/zoneinfo/${TZ} /etc/localtime && \
     echo "${TZ}" > /etc/timezone
+COPY package.json yarn.lock ./
+COPY prisma ./prisma
+RUN yarn install --production --frozen-lockfile --ignore-scripts
 
 COPY --from=build /app/dist ./dist
 


### PR DESCRIPTION
since we changed the docker image (needed for posthog latest version), this fixes this error :
```
yarn run v1.22.22
$ yarn prisma:migrate-prod && yarn prisma:seed && node dist/main
warning Cannot find a suitable global folder. Tried these: "/usr/local, /.yarn"
$ prisma migrate deploy
warning Cannot find a suitable global folder. Tried these: "/usr/local, /.yarn"
prisma:warn Prisma failed to detect the libssl/openssl version to use, and may not work as expected. Defaulting to "openssl-1.1.x".
Please manually install OpenSSL and try installing Prisma again.
Error: Can't write to /app/node_modules/@prisma/engines please make sure you install "prisma" with the right permissions.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```