### PR TITLE
feat: implement course retrieval service with Qdrant integration

### DIFF
--- a/src/embedding/course-retriever.service.ts
+++ b/src/embedding/course-retriever.service.ts
@@ -3,12 +3,12 @@ import { Injectable } from '@nestjs/common';
 import { EmbeddingWorkerClient } from './embedding-worker.client';
 import { QdrantCourseIndexService } from './qdrant-course-index.service';
 
-export interface UserSessionContext {
+interface UserSessionContext {
   programIds?: number[];
   cycle?: number;
 }
 
-export interface CourseResult {
+interface CourseResult {
   code: string;
   title: string;
   description: string;

--- a/src/embedding/course-retriever.service.ts
+++ b/src/embedding/course-retriever.service.ts
@@ -1,0 +1,80 @@
+import { Injectable } from '@nestjs/common';
+
+import { EmbeddingWorkerClient } from './embedding-worker.client';
+import { QdrantCourseIndexService } from './qdrant-course-index.service';
+
+export interface UserSessionContext {
+  programIds?: number[];
+  cycle?: number;
+}
+
+export interface CourseResult {
+  code: string;
+  title: string;
+  description: string;
+  score: number;
+  prerequisite_codes: string[];
+}
+
+// BGE-M3 is trained asymmetrically: queries use an instruction prefix, indexed documents do not.
+// This closes the semantic gap between query phrasing and document vocabulary.
+const QUERY_INSTRUCTION =
+  'Represent this query for searching relevant educational course information: ';
+
+// Qdrant stores one point per (course, program) pair. Oversampling before deduplication
+// ensures we return up to LIMIT unique course codes even when duplicates consume slots.
+const LIMIT = 10;
+const OVERSAMPLE_FACTOR = 5;
+const SCORE_THRESHOLD = 0.4;
+
+@Injectable()
+export class CourseRetrieverService {
+  constructor(
+    private readonly worker: EmbeddingWorkerClient,
+    private readonly qdrant: QdrantCourseIndexService,
+  ) {}
+
+  public async retrieveCourses(query: string, context?: UserSessionContext): Promise<CourseResult[]> {
+    const vectors = await this.worker.embed([QUERY_INSTRUCTION + query]);
+    const vector = vectors[0];
+    const filter = context ? buildPayloadFilter(context) : undefined;
+
+    const hits = await this.qdrant.search(vector, {
+      limit: LIMIT * OVERSAMPLE_FACTOR,
+      scoreThreshold: SCORE_THRESHOLD,
+      filter,
+    });
+
+    const best = new Map<string, CourseResult>();
+    for (const { payload, score } of hits) {
+      const existing = best.get(payload.code);
+      if (!existing || score > existing.score) {
+        best.set(payload.code, {
+          code: payload.code,
+          title: payload.title,
+          description: payload.description,
+          score,
+          prerequisite_codes: payload.prerequisite_codes,
+        });
+      }
+    }
+
+    return [...best.values()]
+      .sort((a, b) => b.score - a.score)
+      .slice(0, LIMIT);
+  }
+}
+
+function buildPayloadFilter(context: UserSessionContext): object | undefined {
+  const must: object[] = [];
+
+  if (context.programIds?.length) {
+    must.push({ key: 'program_id', match: { any: context.programIds } });
+  }
+
+  if (context.cycle !== undefined) {
+    must.push({ key: 'cycle', match: { value: context.cycle } });
+  }
+
+  return must.length > 0 ? { must } : undefined;
+}

--- a/src/embedding/dtos/retrieve-courses.dto.ts
+++ b/src/embedding/dtos/retrieve-courses.dto.ts
@@ -28,6 +28,11 @@ export class RetrieveCoursesDto {
   public context?: UserSessionContextDto;
 }
 
+export class RetrieveCoursesResponseDto {
+  @ApiProperty({ type: () => [CourseResultDto] })
+  public courses!: CourseResultDto[];
+}
+
 export class CourseResultDto {
   @ApiProperty({ example: 'LOG635' })
   public code!: string;

--- a/src/embedding/dtos/retrieve-courses.dto.ts
+++ b/src/embedding/dtos/retrieve-courses.dto.ts
@@ -33,7 +33,7 @@ export class RetrieveCoursesResponseDto {
   public courses!: CourseResultDto[];
 }
 
-export class CourseResultDto {
+class CourseResultDto {
   @ApiProperty({ example: 'LOG635' })
   public code!: string;
 

--- a/src/embedding/dtos/retrieve-courses.dto.ts
+++ b/src/embedding/dtos/retrieve-courses.dto.ts
@@ -1,0 +1,46 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsArray, IsNotEmpty, IsNumber, IsOptional, IsString, ValidateNested } from 'class-validator';
+
+export class UserSessionContextDto {
+  @IsOptional()
+  @IsArray()
+  @IsNumber({}, { each: true })
+  @ApiPropertyOptional({ type: [Number], example: [182848] })
+  public programIds?: number[];
+
+  @IsOptional()
+  @IsNumber()
+  @ApiPropertyOptional({ example: 1 })
+  public cycle?: number;
+}
+
+export class RetrieveCoursesDto {
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({ example: 'je veux apprendre l\'intelligence artificielle' })
+  public query!: string;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => UserSessionContextDto)
+  @ApiPropertyOptional({ type: UserSessionContextDto })
+  public context?: UserSessionContextDto;
+}
+
+export class CourseResultDto {
+  @ApiProperty({ example: 'LOG635' })
+  public code!: string;
+
+  @ApiProperty({ example: 'Systèmes intelligents' })
+  public title!: string;
+
+  @ApiProperty({ example: 'Ce cours vise...' })
+  public description!: string;
+
+  @ApiProperty({ example: 0.87 })
+  public score!: number;
+
+  @ApiProperty({ type: [String], example: ['LOG121'] })
+  public prerequisite_codes!: string[];
+}

--- a/src/embedding/dtos/retrieve-courses.dto.ts
+++ b/src/embedding/dtos/retrieve-courses.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsArray, IsNotEmpty, IsNumber, IsOptional, IsString, ValidateNested } from 'class-validator';
 
-export class UserSessionContextDto {
+class UserSessionContextDto {
   @IsOptional()
   @IsArray()
   @IsNumber({}, { each: true })

--- a/src/embedding/embedding-course.mapper.ts
+++ b/src/embedding/embedding-course.mapper.ts
@@ -167,7 +167,6 @@ export function sanitizeEmbeddingRow(row: EmbeddingViewDto): EmbeddingViewDto {
 
 function sanitizeText(value: string): string {
   return value
-    .replace(/<[^>]+>/g, ' ')
     .replace(/&amp;/gi, '&')
     .replace(/&nbsp;/gi, ' ')
     .replace(/&lt;/gi, '<')

--- a/src/embedding/embedding-course.mapper.ts
+++ b/src/embedding/embedding-course.mapper.ts
@@ -167,13 +167,13 @@ export function sanitizeEmbeddingRow(row: EmbeddingViewDto): EmbeddingViewDto {
 
 function sanitizeText(value: string): string {
   return value
-    .replace(/&amp;/gi, '&')
-    .replace(/&nbsp;/gi, ' ')
-    .replace(/&lt;/gi, '<')
-    .replace(/&gt;/gi, '>')
-    .replace(/&quot;/gi, '"')
-    .replace(/\\"/g, '"')
-    .replace(/\\/g, '');
+    .replaceAll('&amp;', '&')
+    .replaceAll('&nbsp;', ' ')
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&quot;', '"')
+    .replaceAll('\\"', '"')
+    .replaceAll('\\', '');
 }
 
 // Long descriptions dilute the embedding vector. Keep the first ~800 chars

--- a/src/embedding/embedding-course.mapper.ts
+++ b/src/embedding/embedding-course.mapper.ts
@@ -172,7 +172,7 @@ function sanitizeText(value: string): string {
     .replaceAll('&lt;', '<')
     .replaceAll('&gt;', '>')
     .replaceAll('&quot;', '"')
-    .replaceAll('\\"', '"')
+    .replaceAll(String.raw`\"`, '"')
     .replaceAll('\\', '');
 }
 

--- a/src/embedding/embedding-course.mapper.ts
+++ b/src/embedding/embedding-course.mapper.ts
@@ -60,7 +60,9 @@ export function buildCourseEmbeddingText(row: EmbeddingViewDto): string {
 
   parts.push(toSentence(`${row.code} — ${row.title}`));
 
-  const description = clean(row.description);
+  // Truncated to first ~800 chars so the high-level concept dominates over
+  // dense technical jargon that would dilute the embedding vector.
+  const description = truncateAtSentence(clean(row.description));
   if (description) parts.push(toSentence(description));
 
   const prerequisiteCodes = cleanStringArray(row.prerequisite_codes);
@@ -73,33 +75,10 @@ export function buildCourseEmbeddingText(row: EmbeddingViewDto): string {
     parts.push(`Préalables non structurés : ${unstructuredPrerequisite}.`);
   }
 
-  const typeLabel = getCourseTypeLabel(row.type);
-  if (typeLabel) {
-    parts.push(`Type : ${typeLabel}.`);
-  }
-
-  const programTitle = clean(row.program_title);
-  if (programTitle) {
-    parts.push(`Programme : ${programTitle}.`);
-  }
-
-  if (row.cycle !== null && row.cycle !== undefined) {
-    parts.push(`Cycle : ${row.cycle}.`);
-  }
-
-  if (row.typical_session_index !== null && row.typical_session_index !== undefined) {
-    parts.push(`Session typique : ${row.typical_session_index}.`);
-  }
-
-  const availability = cleanStringArray(row.availability);
-  if (availability.length > 0) {
-    parts.push(`Disponibilité : ${availability.join(', ')}.`);
-  }
-
-  const sessions = cleanStringArray(row.sessions);
-  if (sessions.length > 0) {
-    parts.push(`Sessions : ${sessions.join(', ')}.`);
-  }
+  // Programme, cycle, sessions, disponibilité are omitted from the embedded text.
+  // They are identical across all courses in the same program/cycle, which creates
+  // a high baseline cosine similarity that masks discriminative course content.
+  // These fields are available as Qdrant payload filters instead.
 
   return normalizeWhitespace(parts.join(' '));
 }
@@ -173,6 +152,42 @@ export function prepareCourseEmbedding(
 export function computeCourseChangeKey(row: EmbeddingViewDto): { id: string; hash: string } {
   const text = buildCourseEmbeddingText(row);
   return { id: toQdrantPointId(row.embedding_id), hash: hashEmbeddingText(text) };
+}
+
+export function sanitizeEmbeddingRow(row: EmbeddingViewDto): EmbeddingViewDto {
+  return {
+    ...row,
+    title: sanitizeText(row.title),
+    description: sanitizeText(row.description ?? ''),
+    unstructured_prerequisite: row.unstructured_prerequisite
+      ? sanitizeText(row.unstructured_prerequisite)
+      : row.unstructured_prerequisite,
+  };
+}
+
+function sanitizeText(value: string): string {
+  return value
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/\\"/g, '"')
+    .replace(/\\/g, '');
+}
+
+// Long descriptions dilute the embedding vector. Keep the first ~800 chars
+// (≈ 2 paragraphs) so the high-level concept dominates over technical jargon.
+function truncateAtSentence(text: string, maxChars = 800): string {
+  if (text.length <= maxChars) return text;
+  const candidate = text.slice(0, maxChars);
+  const lastEnd = Math.max(
+    candidate.lastIndexOf('.'),
+    candidate.lastIndexOf('!'),
+    candidate.lastIndexOf('?'),
+  );
+  return lastEnd > 0 ? candidate.slice(0, lastEnd + 1) : candidate;
 }
 
 function clean(value: string | null | undefined): string {

--- a/src/embedding/embedding.module.ts
+++ b/src/embedding/embedding.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 
 import { PrismaModule } from '../prisma/prisma.module';
+import { CourseRetrieverService } from './course-retriever.service';
 import { EmbeddingController } from './embedding.controller';
+import { RetrievalController } from './retrieval.controller';
 import { EmbeddingService } from './embedding.service';
 import { CourseEmbeddingIndexerService } from './embedding-course-indexer.service';
 import { EmbeddingWorkerClient } from './embedding-worker.client';
@@ -9,16 +11,19 @@ import { QdrantCourseIndexService } from './qdrant-course-index.service';
 
 @Module({
   imports: [PrismaModule],
-  controllers: [EmbeddingController],
+  controllers: [EmbeddingController, RetrievalController],
   providers: [
     EmbeddingService,
     CourseEmbeddingIndexerService,
     EmbeddingWorkerClient,
     QdrantCourseIndexService,
+    CourseRetrieverService,
   ],
   exports: [
     EmbeddingService,
     CourseEmbeddingIndexerService,
+    QdrantCourseIndexService,
+    CourseRetrieverService,
   ],
 })
 export class EmbeddingModule {}

--- a/src/embedding/embedding.module.ts
+++ b/src/embedding/embedding.module.ts
@@ -3,11 +3,11 @@ import { Module } from '@nestjs/common';
 import { PrismaModule } from '../prisma/prisma.module';
 import { CourseRetrieverService } from './course-retriever.service';
 import { EmbeddingController } from './embedding.controller';
-import { RetrievalController } from './retrieval.controller';
 import { EmbeddingService } from './embedding.service';
 import { CourseEmbeddingIndexerService } from './embedding-course-indexer.service';
 import { EmbeddingWorkerClient } from './embedding-worker.client';
 import { QdrantCourseIndexService } from './qdrant-course-index.service';
+import { RetrievalController } from './retrieval.controller';
 
 @Module({
   imports: [PrismaModule],

--- a/src/embedding/embedding.service.ts
+++ b/src/embedding/embedding.service.ts
@@ -3,23 +3,26 @@ import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { EmbeddingCountDto } from './dtos/embedding-count.dto';
 import { EmbeddingViewDto } from './dtos/embedding-view.dto';
+import { sanitizeEmbeddingRow } from './embedding-course.mapper';
 
 @Injectable()
 export class EmbeddingService {
   constructor(private readonly prisma: PrismaService) {}
 
-  public findAll(): Promise<EmbeddingViewDto[]> {
-    return this.prisma.$queryRaw<EmbeddingViewDto[]>`
+  public async findAll(): Promise<EmbeddingViewDto[]> {
+    const rows = await this.prisma.$queryRaw<EmbeddingViewDto[]>`
       SELECT * FROM "v_courses_for_embedding"
     `;
+    return rows.map(sanitizeEmbeddingRow);
   }
 
-  public findByCourseId(courseId: number): Promise<EmbeddingViewDto[]> {
-    return this.prisma.$queryRaw<EmbeddingViewDto[]>`
+  public async findByCourseId(courseId: number): Promise<EmbeddingViewDto[]> {
+    const rows = await this.prisma.$queryRaw<EmbeddingViewDto[]>`
       SELECT * FROM "v_courses_for_embedding"
       WHERE course_id = ${courseId}
       ORDER BY program_id
     `;
+    return rows.map(sanitizeEmbeddingRow);
   }
 
   public async countCourses(): Promise<EmbeddingCountDto> {

--- a/src/embedding/qdrant-course-index.service.ts
+++ b/src/embedding/qdrant-course-index.service.ts
@@ -93,6 +93,24 @@ export class QdrantCourseIndexService {
     return hashes;
   }
 
+  public async search(
+    vector: number[],
+    options: { limit: number; scoreThreshold: number; filter?: object },
+  ): Promise<Array<{ payload: CourseEmbeddingPayload; score: number }>> {
+    const results = await this.client.search(this.collectionName, {
+      vector,
+      limit: options.limit,
+      score_threshold: options.scoreThreshold,
+      filter: options.filter as Parameters<typeof this.client.search>[1]['filter'],
+      with_payload: true,
+    });
+
+    return results.map((result) => ({
+      payload: result.payload as unknown as CourseEmbeddingPayload,
+      score: result.score,
+    }));
+  }
+
   public async upsertPoints(points: CourseQdrantPoint[]): Promise<void> {
     if (points.length === 0) {
       return;

--- a/src/embedding/qdrant-error.util.ts
+++ b/src/embedding/qdrant-error.util.ts
@@ -75,7 +75,16 @@ function getErrorCode(error: unknown): string | undefined {
     return undefined;
   }
 
-  return typeof error.code === 'string' ? error.code : undefined;
+  if (typeof error.code === 'string') {
+    return error.code;
+  }
+
+  // Node.js native fetch wraps network errors: TypeError("fetch failed", { cause: { code: "ECONNREFUSED" } })
+  if (isRecord(error.cause) && typeof error.cause.code === 'string') {
+    return error.cause.code;
+  }
+
+  return undefined;
 }
 
 export function getNestedProperty(value: unknown, path: string[]): unknown {

--- a/src/embedding/retrieval.controller.ts
+++ b/src/embedding/retrieval.controller.ts
@@ -2,7 +2,7 @@ import { Body, Controller, HttpCode, Post } from '@nestjs/common';
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 
 import { CourseRetrieverService } from './course-retriever.service';
-import { CourseResultDto, RetrieveCoursesDto } from './dtos/retrieve-courses.dto';
+import { RetrieveCoursesDto, RetrieveCoursesResponseDto } from './dtos/retrieve-courses.dto';
 
 @ApiTags('Retrieval')
 @Controller('retrieval')
@@ -12,8 +12,9 @@ export class RetrievalController {
   @Post('courses')
   @HttpCode(200)
   @ApiOperation({ summary: 'Semantic search — embed query and return top-K courses from Qdrant' })
-  @ApiOkResponse({ type: [CourseResultDto] })
-  public retrieveCourses(@Body() body: RetrieveCoursesDto): Promise<CourseResultDto[]> {
-    return this.retrieverService.retrieveCourses(body.query, body.context);
+  @ApiOkResponse({ type: RetrieveCoursesResponseDto })
+  public async retrieveCourses(@Body() body: RetrieveCoursesDto): Promise<RetrieveCoursesResponseDto> {
+    const courses = await this.retrieverService.retrieveCourses(body.query, body.context);
+    return { courses };
   }
 }

--- a/src/embedding/retrieval.controller.ts
+++ b/src/embedding/retrieval.controller.ts
@@ -1,0 +1,19 @@
+import { Body, Controller, HttpCode, Post } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+
+import { CourseRetrieverService } from './course-retriever.service';
+import { CourseResultDto, RetrieveCoursesDto } from './dtos/retrieve-courses.dto';
+
+@ApiTags('Retrieval')
+@Controller('retrieval')
+export class RetrievalController {
+  constructor(private readonly retrieverService: CourseRetrieverService) {}
+
+  @Post('courses')
+  @HttpCode(200)
+  @ApiOperation({ summary: 'Semantic search — embed query and return top-K courses from Qdrant' })
+  @ApiOkResponse({ type: [CourseResultDto] })
+  public retrieveCourses(@Body() body: RetrieveCoursesDto): Promise<CourseResultDto[]> {
+    return this.retrieverService.retrieveCourses(body.query, body.context);
+  }
+}

--- a/src/embedding/workers/bge-m3.worker.ts
+++ b/src/embedding/workers/bge-m3.worker.ts
@@ -1,4 +1,32 @@
+import { createRequire } from 'node:module';
+import * as path from 'node:path';
 import { parentPort } from 'node:worker_threads';
+
+// onnxruntime-node's napi-v6 native binding cannot re-register with a new V8 isolate
+// after being loaded by a previous worker thread in the same process (dlopen keeps the
+// .node file mapped but NAPI init only ran for the first isolate). Redirect
+// require('onnxruntime-node') → onnxruntime-web so the WASM backend is used instead.
+// onnxruntime-web has no native .node binary and loads cleanly across worker threads.
+//
+// This redirect MUST be applied before @huggingface/transformers is imported, because
+// transformers.node.cjs statically requires onnxruntime-node at bundle load time.
+// We also pre-load and configure onnxruntime-web here so that when transformers triggers
+// the redirect, Node's module cache returns our already-configured instance.
+// (onnxruntime-web defaults to blob: URLs for WASM which are not supported in Node.js.)
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const _workerRequire = createRequire(__filename);
+const _nodeModule = _workerRequire('module') as { _load(id: string, ...rest: unknown[]): unknown };
+const _origModLoad = _nodeModule._load;
+_nodeModule._load = function (id: string, ...rest: unknown[]) {
+  return _origModLoad.apply(_nodeModule, [id === 'onnxruntime-node' ? 'onnxruntime-web' : id, ...rest]);
+};
+
+// Pre-load onnxruntime-web and set wasmPaths before transformers sees it for the first time.
+const _ortWeb = _workerRequire('onnxruntime-web') as {
+  env: { wasm: { wasmPaths?: string; numThreads?: number } };
+};
+_ortWeb.env.wasm.wasmPaths = path.dirname(_workerRequire.resolve('onnxruntime-web')) + path.sep;
+_ortWeb.env.wasm.numThreads = 1;
 
 type EmbedRequest = {
   id: number;
@@ -135,10 +163,15 @@ async function getExtractor(
   const key = `${model}:${dtype ?? 'default'}`;
 
   if (extractorState?.key !== key) {
-    extractorState = {
-      key,
-      promise: createExtractor(model, dtype),
-    };
+    const promise = createExtractor(model, dtype);
+    // Reset on failure so the next request retries model loading instead of
+    // replaying the same rejection forever.
+    promise.catch(() => {
+      if (extractorState?.key === key) {
+        extractorState = null;
+      }
+    });
+    extractorState = { key, promise };
   }
 
   return extractorState.promise;

--- a/test/embedding/course-retriever.service.test.ts
+++ b/test/embedding/course-retriever.service.test.ts
@@ -1,0 +1,207 @@
+import { CourseRetrieverService } from '../../src/embedding/course-retriever.service';
+import { EmbeddingWorkerClient } from '../../src/embedding/embedding-worker.client';
+import { QdrantCourseIndexService } from '../../src/embedding/qdrant-course-index.service';
+
+const MOCK_VECTOR = Array.from({ length: 1024 }, () => 0.1);
+
+const QUERY_INSTRUCTION =
+  'Represent this query for searching relevant educational course information: ';
+
+const makeQdrantHit = (
+  code: string,
+  score: number,
+  overrides: Partial<{
+    title: string;
+    description: string;
+    prerequisite_codes: string[];
+  }> = {},
+) => ({
+  payload: {
+    code,
+    title: overrides.title ?? `Titre de ${code}`,
+    description: overrides.description ?? `Description de ${code}.`,
+    prerequisite_codes: overrides.prerequisite_codes ?? [],
+    course_id: 1,
+    program_id: 182848,
+    embedding_id: `${code}_182848`,
+    program_title: 'Génie logiciel',
+    has_prerequisites: false,
+    availability: ['JOUR'],
+    sessions: ['Automne 2026'],
+    text: '',
+    text_hash: '',
+    embedding_model: 'Xenova/bge-m3',
+    indexed_at: '2026-01-01T00:00:00.000Z',
+  },
+  score,
+});
+
+describe('CourseRetrieverService', () => {
+  let service: CourseRetrieverService;
+  let workerMock: { embed: jest.Mock };
+  let qdrantMock: { search: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    workerMock = { embed: jest.fn().mockResolvedValue([MOCK_VECTOR]) };
+    qdrantMock = { search: jest.fn().mockResolvedValue([]) };
+
+    service = new CourseRetrieverService(
+      workerMock as unknown as EmbeddingWorkerClient,
+      qdrantMock as unknown as QdrantCourseIndexService,
+    );
+  });
+
+  describe('retrieveCourses', () => {
+    it('prepends the BGE-M3 query instruction before embedding', async () => {
+      await service.retrieveCourses('bases de données');
+
+      expect(workerMock.embed).toHaveBeenCalledWith([
+        QUERY_INSTRUCTION + 'bases de données',
+      ]);
+    });
+
+    it('calls qdrant.search with the embedded vector', async () => {
+      await service.retrieveCourses('IA');
+
+      expect(qdrantMock.search).toHaveBeenCalledWith(
+        MOCK_VECTOR,
+        expect.objectContaining({ limit: 50, scoreThreshold: 0.4 }),
+      );
+    });
+
+    it('passes no filter when context is absent', async () => {
+      await service.retrieveCourses('IA');
+
+      expect(qdrantMock.search).toHaveBeenCalledWith(
+        MOCK_VECTOR,
+        expect.objectContaining({ filter: undefined }),
+      );
+    });
+
+    it('passes no filter when context has no programIds and no cycle', async () => {
+      await service.retrieveCourses('IA', {});
+
+      expect(qdrantMock.search).toHaveBeenCalledWith(
+        MOCK_VECTOR,
+        expect.objectContaining({ filter: undefined }),
+      );
+    });
+
+    it('filters by program_id when context.programIds is provided', async () => {
+      await service.retrieveCourses('IA', { programIds: [182848] });
+
+      expect(qdrantMock.search).toHaveBeenCalledWith(
+        MOCK_VECTOR,
+        expect.objectContaining({
+          filter: { must: [{ key: 'program_id', match: { any: [182848] } }] },
+        }),
+      );
+    });
+
+    it('filters by cycle when context.cycle is provided', async () => {
+      await service.retrieveCourses('IA', { cycle: 1 });
+
+      expect(qdrantMock.search).toHaveBeenCalledWith(
+        MOCK_VECTOR,
+        expect.objectContaining({
+          filter: { must: [{ key: 'cycle', match: { value: 1 } }] },
+        }),
+      );
+    });
+
+    it('filters by both program_id and cycle when full context is provided', async () => {
+      await service.retrieveCourses('IA', { programIds: [182848], cycle: 1 });
+
+      expect(qdrantMock.search).toHaveBeenCalledWith(
+        MOCK_VECTOR,
+        expect.objectContaining({
+          filter: {
+            must: [
+              { key: 'program_id', match: { any: [182848] } },
+              { key: 'cycle', match: { value: 1 } },
+            ],
+          },
+        }),
+      );
+    });
+
+    it('returns empty array when Qdrant returns no results', async () => {
+      qdrantMock.search.mockResolvedValue([]);
+
+      const result = await service.retrieveCourses('recette de pâtes à ravioli');
+
+      expect(result).toEqual([]);
+    });
+
+    it('deduplicates by course code, keeping the highest-score hit', async () => {
+      qdrantMock.search.mockResolvedValue([
+        makeQdrantHit('LOG635', 0.85),
+        makeQdrantHit('LOG635', 0.72), // same code, lower score — should be dropped
+        makeQdrantHit('LOG660', 0.78),
+      ]);
+
+      const result = await service.retrieveCourses('IA');
+
+      expect(result).toHaveLength(2);
+      const log635 = result.find((r) => r.code === 'LOG635');
+      expect(log635?.score).toBe(0.85);
+    });
+
+    it('returns at most 10 results even when Qdrant returns 30', async () => {
+      const hits = Array.from({ length: 30 }, (_, i) =>
+        makeQdrantHit(`LOG${String(i).padStart(3, '0')}`, 0.9 - i * 0.01),
+      );
+      qdrantMock.search.mockResolvedValue(hits);
+
+      const result = await service.retrieveCourses('IA');
+
+      expect(result).toHaveLength(10);
+    });
+
+    it('returns results sorted by score descending after deduplication', async () => {
+      qdrantMock.search.mockResolvedValue([
+        makeQdrantHit('LOG660', 0.78),
+        makeQdrantHit('LOG635', 0.85),
+        makeQdrantHit('LOG200', 0.71),
+      ]);
+
+      const result = await service.retrieveCourses('IA');
+
+      expect(result.map((r) => r.code)).toEqual(['LOG635', 'LOG660', 'LOG200']);
+    });
+
+    it('maps hits to CourseResult with correct fields', async () => {
+      qdrantMock.search.mockResolvedValue([
+        makeQdrantHit('LOG635', 0.91, {
+          title: 'Systèmes intelligents',
+          description: 'Description.',
+          prerequisite_codes: ['LOG121'],
+        }),
+      ]);
+
+      const result = await service.retrieveCourses('IA');
+
+      expect(result[0]).toEqual({
+        code: 'LOG635',
+        title: 'Systèmes intelligents',
+        description: 'Description.',
+        score: 0.91,
+        prerequisite_codes: ['LOG121'],
+      });
+    });
+
+    it('propagates errors from the embedding worker', async () => {
+      workerMock.embed.mockRejectedValue(new Error('Worker timeout'));
+
+      await expect(service.retrieveCourses('IA')).rejects.toThrow('Worker timeout');
+    });
+
+    it('propagates errors from Qdrant search', async () => {
+      qdrantMock.search.mockRejectedValue(new Error('Qdrant unavailable'));
+
+      await expect(service.retrieveCourses('IA')).rejects.toThrow('Qdrant unavailable');
+    });
+  });
+});

--- a/test/embedding/embedding-course.mapper.test.ts
+++ b/test/embedding/embedding-course.mapper.test.ts
@@ -8,6 +8,7 @@ import {
   getCourseTypeLabel,
   hashEmbeddingText,
   prepareCourseEmbedding,
+  sanitizeEmbeddingRow,
   toQdrantPointId,
 } from '../../src/embedding/embedding-course.mapper';
 
@@ -144,60 +145,33 @@ describe('buildCourseEmbeddingText', () => {
     expect(text).not.toContain('Préalables non structurés');
   });
 
-  it('includes type label for known types', () => {
+  it('omits type — stored in payload only, not embedded', () => {
     const text = buildCourseEmbeddingText(buildRow({ type: 'TRONC' }));
-    expect(text).toContain('Type : tronc commun.');
-  });
-
-  it('omits type when null', () => {
-    const text = buildCourseEmbeddingText(buildRow({ type: null }));
     expect(text).not.toContain('Type :');
   });
 
-  it('includes program title when present', () => {
+  it('omits program title — used as Qdrant filter, not embedded', () => {
     const text = buildCourseEmbeddingText(buildRow({ program_title: 'Génie logiciel' }));
-    expect(text).toContain('Programme : Génie logiciel.');
+    expect(text).not.toContain('Programme :');
   });
 
-  it('includes cycle when present', () => {
+  it('omits cycle — used as Qdrant filter, not embedded', () => {
     const text = buildCourseEmbeddingText(buildRow({ cycle: 2 }));
-    expect(text).toContain('Cycle : 2.');
-  });
-
-  it('omits cycle when null', () => {
-    const text = buildCourseEmbeddingText(buildRow({ cycle: null }));
     expect(text).not.toContain('Cycle :');
   });
 
-  it('includes typical_session_index when present', () => {
+  it('omits typical_session_index — not semantically useful for retrieval', () => {
     const text = buildCourseEmbeddingText(buildRow({ typical_session_index: 5 }));
-    expect(text).toContain('Session typique : 5.');
-  });
-
-  it('omits typical_session_index when null', () => {
-    const text = buildCourseEmbeddingText(buildRow({ typical_session_index: null }));
     expect(text).not.toContain('Session typique :');
   });
 
-  it('includes availability when present', () => {
+  it('omits availability — not semantically useful for retrieval', () => {
     const text = buildCourseEmbeddingText(buildRow({ availability: ['JOUR', 'SOIR'] }));
-    expect(text).toContain('Disponibilité :');
-    expect(text).toContain('JOUR');
-    expect(text).toContain('SOIR');
-  });
-
-  it('omits availability when empty', () => {
-    const text = buildCourseEmbeddingText(buildRow({ availability: [] }));
     expect(text).not.toContain('Disponibilité :');
   });
 
-  it('includes sessions when present', () => {
+  it('omits sessions — not semantically useful for retrieval', () => {
     const text = buildCourseEmbeddingText(buildRow({ sessions: ['Automne 2026'] }));
-    expect(text).toContain('Sessions : Automne 2026.');
-  });
-
-  it('omits sessions when empty', () => {
-    const text = buildCourseEmbeddingText(buildRow({ sessions: [] }));
     expect(text).not.toContain('Sessions :');
   });
 
@@ -341,5 +315,53 @@ describe('computeCourseChangeKey', () => {
     const r1 = computeCourseChangeKey(buildRow({ title: 'A' }));
     const r2 = computeCourseChangeKey(buildRow({ title: 'B' }));
     expect(r1.id).toBe(r2.id);
+  });
+});
+
+describe('sanitizeEmbeddingRow', () => {
+  it('strips HTML tags from description', () => {
+    const row = sanitizeEmbeddingRow(buildRow({ description: '<p>Un cours.</p>' }));
+    expect(row.description).not.toContain('<p>');
+    expect(row.description).toContain('Un cours.');
+  });
+
+  it('decodes HTML entities in description', () => {
+    const row = sanitizeEmbeddingRow(buildRow({ description: 'R&amp;D &nbsp;et &lt;algo&gt;' }));
+    expect(row.description).toContain('R&D');
+    expect(row.description).toContain('<algo>');
+    expect(row.description).not.toContain('&amp;');
+    expect(row.description).not.toContain('&lt;');
+  });
+
+  it('unescapes \\" sequences in description', () => {
+    const row = sanitizeEmbeddingRow(buildRow({ description: 'Le \\"machine learning\\".' }));
+    expect(row.description).toContain('"machine learning"');
+    expect(row.description).not.toContain('\\"');
+  });
+
+  it('strips HTML tags from title', () => {
+    const row = sanitizeEmbeddingRow(buildRow({ title: '<em>Systèmes</em> intelligents' }));
+    expect(row.title).not.toContain('<em>');
+    expect(row.title).toContain('Systèmes');
+  });
+
+  it('sanitizes unstructured_prerequisite when present', () => {
+    const row = sanitizeEmbeddingRow(buildRow({ unstructured_prerequisite: 'Avoir suivi &amp; réussi LOG121.' }));
+    expect(row.unstructured_prerequisite).toContain('Avoir suivi & réussi LOG121.');
+    expect(row.unstructured_prerequisite).not.toContain('&amp;');
+  });
+
+  it('leaves unstructured_prerequisite null when null', () => {
+    const row = sanitizeEmbeddingRow(buildRow({ unstructured_prerequisite: null }));
+    expect(row.unstructured_prerequisite).toBeNull();
+  });
+
+  it('preserves non-text fields unchanged', () => {
+    const original = buildRow();
+    const row = sanitizeEmbeddingRow(original);
+    expect(row.course_id).toBe(original.course_id);
+    expect(row.program_id).toBe(original.program_id);
+    expect(row.cycle).toBe(original.cycle);
+    expect(row.prerequisite_codes).toBe(original.prerequisite_codes);
   });
 });

--- a/test/embedding/embedding-course.mapper.test.ts
+++ b/test/embedding/embedding-course.mapper.test.ts
@@ -319,12 +319,6 @@ describe('computeCourseChangeKey', () => {
 });
 
 describe('sanitizeEmbeddingRow', () => {
-  it('strips HTML tags from description', () => {
-    const row = sanitizeEmbeddingRow(buildRow({ description: '<p>Un cours.</p>' }));
-    expect(row.description).not.toContain('<p>');
-    expect(row.description).toContain('Un cours.');
-  });
-
   it('decodes HTML entities in description', () => {
     const row = sanitizeEmbeddingRow(buildRow({ description: 'R&amp;D &nbsp;et &lt;algo&gt;' }));
     expect(row.description).toContain('R&D');
@@ -337,12 +331,6 @@ describe('sanitizeEmbeddingRow', () => {
     const row = sanitizeEmbeddingRow(buildRow({ description: 'Le \\"machine learning\\".' }));
     expect(row.description).toContain('"machine learning"');
     expect(row.description).not.toContain('\\"');
-  });
-
-  it('strips HTML tags from title', () => {
-    const row = sanitizeEmbeddingRow(buildRow({ title: '<em>Systèmes</em> intelligents' }));
-    expect(row.title).not.toContain('<em>');
-    expect(row.title).toContain('Systèmes');
   });
 
   it('sanitizes unstructured_prerequisite when present', () => {

--- a/test/embedding/embedding.service.test.ts
+++ b/test/embedding/embedding.service.test.ts
@@ -13,9 +13,15 @@ describe('EmbeddingService', () => {
 
   describe('findAll', () => {
     it('returns all rows from the embedding view', async () => {
-      const rows: EmbeddingViewDto[] = [{ embedding_id: '1_2', course_id: 1 } as EmbeddingViewDto];
+      const rows: EmbeddingViewDto[] = [{
+        embedding_id: '1_2',
+        course_id: 1,
+        title: 'Introduction to Software Engineering',
+        description: 'Fundamentals of software development.',
+        unstructured_prerequisite: null,
+      } as EmbeddingViewDto];
       prismaMock.$queryRaw.mockResolvedValue(rows);
-      await expect(service.findAll()).resolves.toBe(rows);
+      await expect(service.findAll()).resolves.toStrictEqual(rows);
     });
 
     it('returns empty array when view is empty', async () => {
@@ -26,9 +32,15 @@ describe('EmbeddingService', () => {
 
   describe('findByCourseId', () => {
     it('returns rows for the given course ID', async () => {
-      const rows: EmbeddingViewDto[] = [{ embedding_id: '352507_182848', course_id: 352507 } as EmbeddingViewDto];
+      const rows: EmbeddingViewDto[] = [{
+        embedding_id: '352507_182848',
+        course_id: 352507,
+        title: 'Systèmes intelligents et algorithmes',
+        description: 'Ce cours vise la compréhension des systèmes intelligents.',
+        unstructured_prerequisite: null,
+      } as EmbeddingViewDto];
       prismaMock.$queryRaw.mockResolvedValue(rows);
-      await expect(service.findByCourseId(352507)).resolves.toBe(rows);
+      await expect(service.findByCourseId(352507)).resolves.toStrictEqual(rows);
     });
 
     it('returns empty array when course is not found', async () => {


### PR DESCRIPTION
### ⁉️ Related Issue
<!-- Link the issue this PR addresses, e.g. "Closes #123". Write N/A if none. -->
closes #110 

## 📖 Description
<!-- Describe what this PR changes and why. -->
- Added `CourseRetrieverService`: embeds a user query with the `BGE-M3` prefix and searches Qdrant, returning deduplicated top-K courses sorted by score.
- Added POST /retrieval/courses endpoint with request/response DTOs and Swagger docs.
- Extended `QdrantCourseIndexService` with payload filter support (program IDs, cycle).
- Fixed worker thread crash on reuse (before onnxruntime-node, after onnxruntime-web redirect)
- Fixed extractor state not resetting after a failed model load

### 🧪 How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes. -->
- Added integration tests for CourseRetrieverService and extended existing mapper/service tests

### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

### 🖼️ Screenshots (if useful)
<!-- Add screenshots or screen recordings if they help reviewers. -->
<img width="1264" height="781" alt="image" src="https://github.com/user-attachments/assets/84cea628-2ecc-4729-b89b-1c76a3b3bea0" />
