### PR TITLE
disable chatbot routes and jobs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,3 +48,5 @@ GEMINI_MODEL="gemini-2.5-flash-lite"
 # Monitoring
 # POSTHOG_API_KEY=""
 # POSTHOG_HOST="https://us.i.posthog.com"
+
+CHATBOT_ENABLED=false

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@huggingface/transformers": "^4.2.0",
     "@nestjs/axios": "^3.1.1",
     "@nestjs/common": "^10.4.10",
+    "@nestjs/config": "^4.0.4",
     "@nestjs/core": "^10.4.10",
     "@nestjs/platform-express": "^10.4.22",
     "@nestjs/schedule": "^4.1.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,10 +1,12 @@
 import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 
 import { AppController } from './app.controller';
 import { CheminotModule } from './common/api-helper/cheminot/cheminot.module';
 import { EtsModule } from './common/api-helper/ets/ets.module';
 import { PdfModule } from './common/website-helper/pdf/pdf.module';
+import chatbotConfig from './config/chatbot.config';
 import { CourseModule } from './course/course.module';
 import { CourseInstanceModule } from './course-instance/course-instance.module';
 import { EmbeddingModule } from './embedding/embedding.module';
@@ -35,7 +37,13 @@ import { SessionModule } from './session/session.module';
     ProgramModule,
     ProgramCourseModule,
     EmbeddingModule,
-    LlmGenerationModule
+    LlmGenerationModule,
+
+    // Config
+    ConfigModule.forRoot({
+      isGlobal: true,
+      load: [chatbotConfig]
+    })
   ],
   controllers: [AppController],
   exports: [HttpModule]

--- a/src/common/guards/chatbot-enabled.guard.ts
+++ b/src/common/guards/chatbot-enabled.guard.ts
@@ -1,0 +1,25 @@
+import {
+  CanActivate,
+  Inject,
+  Injectable,
+  NotFoundException
+} from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+
+import chatbotConfig from '../../config/chatbot.config';
+
+@Injectable()
+export class ChatbotEnabledGuard implements CanActivate {
+  constructor(
+    @Inject(chatbotConfig.KEY)
+    private readonly chatbotConfiguration: ConfigType<typeof chatbotConfig>
+  ) {}
+
+  public canActivate(): boolean {
+    if (!this.chatbotConfiguration.enabled) {
+      throw new NotFoundException();
+    }
+
+    return true;
+  }
+}

--- a/src/config/chatbot.config.ts
+++ b/src/config/chatbot.config.ts
@@ -1,0 +1,5 @@
+import { registerAs } from '@nestjs/config';
+
+export default registerAs('chatbot', () => ({
+  enabled: (process.env.CHATBOT_ENABLED ?? 'false').toLowerCase() === 'true'
+}));

--- a/src/embedding/embedding.controller.ts
+++ b/src/embedding/embedding.controller.ts
@@ -1,4 +1,10 @@
-import { Controller, Get, Param, ParseIntPipe, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  UseGuards
+} from '@nestjs/common';
 import {
   ApiOkResponse,
   ApiOperation,

--- a/src/embedding/embedding.controller.ts
+++ b/src/embedding/embedding.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
+import { Controller, Get, Param, ParseIntPipe, UseGuards } from '@nestjs/common';
 import {
   ApiOkResponse,
   ApiOperation,
@@ -6,11 +6,13 @@ import {
   ApiTags
 } from '@nestjs/swagger';
 
+import { ChatbotEnabledGuard } from '../common/guards/chatbot-enabled.guard';
 import { EmbeddingCountDto } from './dtos/embedding-count.dto';
 import { EmbeddingViewDto } from './dtos/embedding-view.dto';
 import { EmbeddingService } from './embedding.service';
 
 @ApiTags('Chatbot')
+@UseGuards(ChatbotEnabledGuard)
 @Controller('embedding-view')
 export class EmbeddingController {
   constructor(private readonly embeddingService: EmbeddingService) {}

--- a/src/embedding/embedding.module.ts
+++ b/src/embedding/embedding.module.ts
@@ -1,5 +1,8 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 
+import { ChatbotEnabledGuard } from '../common/guards/chatbot-enabled.guard';
+import chatbotConfig from '../config/chatbot.config';
 import { PrismaModule } from '../prisma/prisma.module';
 import { CourseRetrieverService } from './course-retriever.service';
 import { EmbeddingController } from './embedding.controller';
@@ -10,14 +13,15 @@ import { QdrantCourseIndexService } from './qdrant-course-index.service';
 import { RetrievalController } from './retrieval.controller';
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, ConfigModule.forFeature(chatbotConfig)],
   controllers: [EmbeddingController, RetrievalController],
   providers: [
     EmbeddingService,
     CourseEmbeddingIndexerService,
     EmbeddingWorkerClient,
     QdrantCourseIndexService,
-    CourseRetrieverService
+    CourseRetrieverService,
+    ChatbotEnabledGuard
   ],
   exports: [
     EmbeddingService,

--- a/src/embedding/retrieval.controller.ts
+++ b/src/embedding/retrieval.controller.ts
@@ -1,6 +1,7 @@
-import { Body, Controller, HttpCode, Post } from '@nestjs/common';
+import { Body, Controller, HttpCode, Post, UseGuards } from '@nestjs/common';
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 
+import { ChatbotEnabledGuard } from '../common/guards/chatbot-enabled.guard';
 import { CourseRetrieverService } from './course-retriever.service';
 import {
   RetrieveCoursesDto,
@@ -8,6 +9,7 @@ import {
 } from './dtos/retrieve-courses.dto';
 
 @ApiTags('Chatbot')
+@UseGuards(ChatbotEnabledGuard)
 @Controller('retrieval')
 export class RetrievalController {
   constructor(private readonly retrieverService: CourseRetrieverService) {}

--- a/src/jobs/jobs.constants.ts
+++ b/src/jobs/jobs.constants.ts
@@ -20,6 +20,7 @@ export const jobWorkerProviders: Provider[] = [
   CoursesJobService,
   CourseInstancesJobService,
   SessionsJobService,
+  CourseEmbeddingIndexerService,
   CourseCodeValidationPipe
 ];
 

--- a/src/jobs/jobs.constants.ts
+++ b/src/jobs/jobs.constants.ts
@@ -20,7 +20,6 @@ export const jobWorkerProviders: Provider[] = [
   CoursesJobService,
   CourseInstancesJobService,
   SessionsJobService,
-  CourseEmbeddingIndexerService,
   CourseCodeValidationPipe
 ];
 

--- a/src/jobs/jobs.controller.ts
+++ b/src/jobs/jobs.controller.ts
@@ -51,8 +51,12 @@ export class JobsController {
       });
     if (processSessions)
       jobs.push({ service: 'SessionsJobService', method: 'processSessions' });
-    if (processCourseEmbeddings)
-      jobs.push({ service: 'CourseEmbeddingIndexerService', method: 'run' });
+    if (processCourseEmbeddings) {
+      jobs.push({
+        service: 'CourseEmbeddingIndexerService',
+        method: 'run'
+      });
+    }
 
     if (jobs.length === 0) {
       return { status: 'No jobs triggered (no flags set)' };
@@ -60,6 +64,15 @@ export class JobsController {
 
     const results = [];
     for (const job of jobs) {
+      if (!this.jobsService.canRunJob(job.service, job.method)) {
+        results.push({
+          job,
+          status: 'skipped',
+          reason: 'CHATBOT_ENABLED=false'
+        });
+        continue;
+      }
+
       try {
         await this.jobsService.runWorker(job.service, job.method);
         results.push({ job, status: 'success' });

--- a/src/jobs/jobs.controller.ts
+++ b/src/jobs/jobs.controller.ts
@@ -4,86 +4,145 @@ import { ApiBody, ApiTags } from '@nestjs/swagger';
 import { RunWorkersDto } from './dtos/run-workers.dto';
 import { JobsService } from './jobs.service';
 
+type JobDefinition = {
+  service: string;
+  method: string;
+};
+
+type JobFlag =
+  | 'processPrograms'
+  | 'processCourses'
+  | 'processCourseDescriptions'
+  | 'processCourseInstances'
+  | 'processProgramCourses'
+  | 'processSessions'
+  | 'processCourseEmbeddings';
+
+type JobFlagMapping = {
+  flag: JobFlag;
+  job: JobDefinition;
+};
+
+type JobResult =
+  | {
+      job: JobDefinition;
+      status: 'success';
+    }
+  | {
+      job: JobDefinition;
+      status: 'skipped';
+      reason: string;
+    }
+  | {
+      job: JobDefinition;
+      status: 'error';
+      error: string;
+    };
+
 @ApiTags('jobs')
 @Controller('jobs')
 export class JobsController {
+  private readonly jobMappings: JobFlagMapping[] = [
+    {
+      flag: 'processPrograms',
+      job: { service: 'ProgramsJobService', method: 'processPrograms' }
+    },
+    {
+      flag: 'processCourses',
+      job: { service: 'CoursesJobService', method: 'processCourses' }
+    },
+    {
+      flag: 'processCourseDescriptions',
+      job: {
+        service: 'CoursesJobService',
+        method: 'syncCourseDescriptionsFromEtsWebsite'
+      }
+    },
+    {
+      flag: 'processCourseInstances',
+      job: {
+        service: 'CourseInstancesJobService',
+        method: 'processCourseInstances'
+      }
+    },
+    {
+      flag: 'processProgramCourses',
+      job: {
+        service: 'CoursesJobService',
+        method: 'syncCourseDetailsWithCheminotData'
+      }
+    },
+    {
+      flag: 'processSessions',
+      job: { service: 'SessionsJobService', method: 'processSessions' }
+    },
+    {
+      flag: 'processCourseEmbeddings',
+      job: { service: 'CourseEmbeddingIndexerService', method: 'run' }
+    }
+  ];
+
   constructor(private readonly jobsService: JobsService) {}
 
   @Post('run-workers')
   @ApiBody({ type: RunWorkersDto })
   public async runWorkers(@Body() body: RunWorkersDto) {
-    const {
-      processAllJobs = true,
-      processPrograms = false,
-      processCourses = false,
-      processCourseDescriptions = false,
-      processCourseInstances = false,
-      processProgramCourses = false,
-      processSessions = false,
-      processCourseEmbeddings = false
-    } = body || {};
+    const request = body ?? {};
 
-    if (processAllJobs) {
+    if (request.processAllJobs ?? true) {
       await this.jobsService.processJobs();
       return { status: 'All jobs have been triggered' };
     }
 
-    // Map flags to jobs
-    const jobs: { service: string; method: string }[] = [];
-    if (processPrograms)
-      jobs.push({ service: 'ProgramsJobService', method: 'processPrograms' });
-    if (processCourses)
-      jobs.push({ service: 'CoursesJobService', method: 'processCourses' });
-    if (processCourseDescriptions)
-      jobs.push({
-        service: 'CoursesJobService',
-        method: 'syncCourseDescriptionsFromEtsWebsite'
-      });
-    if (processCourseInstances)
-      jobs.push({
-        service: 'CourseInstancesJobService',
-        method: 'processCourseInstances'
-      });
-    if (processProgramCourses)
-      jobs.push({
-        service: 'CoursesJobService',
-        method: 'syncCourseDetailsWithCheminotData'
-      });
-    if (processSessions)
-      jobs.push({ service: 'SessionsJobService', method: 'processSessions' });
-    if (processCourseEmbeddings) {
-      jobs.push({
-        service: 'CourseEmbeddingIndexerService',
-        method: 'run'
-      });
-    }
+    const jobs = this.getSelectedJobs(request);
 
     if (jobs.length === 0) {
       return { status: 'No jobs triggered (no flags set)' };
     }
 
-    const results = [];
-    for (const job of jobs) {
-      if (!this.jobsService.canRunJob(job.service, job.method)) {
-        results.push({
-          job,
-          status: 'skipped',
-          reason: 'CHATBOT_ENABLED=false'
-        });
-        continue;
-      }
+    const results = await this.runSelectedJobs(jobs);
 
-      try {
-        await this.jobsService.runWorker(job.service, job.method);
-        results.push({ job, status: 'success' });
-      } catch (error) {
-        results.push({
-          job,
-          status: 'error',
-          error: error instanceof Error ? error.message : String(error)
-        });
-      }
-    }
     return { status: 'Selected jobs processed', results };
+  }
+
+  private getSelectedJobs(body: RunWorkersDto): JobDefinition[] {
+    return this.jobMappings
+      .filter(({ flag }) => body[flag])
+      .map(({ job }) => job);
+  }
+
+  private async runSelectedJobs(jobs: JobDefinition[]): Promise<JobResult[]> {
+    const results: JobResult[] = [];
+
+    for (const job of jobs) {
+      results.push(await this.runSelectedJob(job));
+    }
+
+    return results;
+  }
+
+  private async runSelectedJob(job: JobDefinition): Promise<JobResult> {
+    if (!this.jobsService.canRunJob(job.service, job.method)) {
+      return {
+        job,
+        status: 'skipped',
+        reason: 'CHATBOT_ENABLED=false'
+      };
+    }
+
+    try {
+      await this.jobsService.runWorker(job.service, job.method);
+      return { job, status: 'success' };
+    } catch (error) {
+      return {
+        job,
+        status: 'error',
+        error: this.getErrorMessage(error)
+      };
+    }
+  }
+
+  private getErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
   }
 }

--- a/src/jobs/jobs.service.ts
+++ b/src/jobs/jobs.service.ts
@@ -11,10 +11,10 @@ export class JobsService {
   private readonly chatbotEnabled: boolean;
 
   constructor(private readonly configService: ConfigService) {
-    this.chatbotEnabled =
-      this.configService
-        .get<string>('CHATBOT_ENABLED', 'false')
-        .toLowerCase() === 'true';
+    this.chatbotEnabled = this.configService.get<boolean>(
+      'chatbot.enabled',
+      false
+    );
   }
 
   public isChatbotJob(serviceName: string, methodName: string): boolean {

--- a/src/jobs/jobs.service.ts
+++ b/src/jobs/jobs.service.ts
@@ -12,8 +12,9 @@ export class JobsService {
 
   constructor(private readonly configService: ConfigService) {
     this.chatbotEnabled =
-      this.configService.get<string>('CHATBOT_ENABLED', 'false').toLowerCase() ===
-      'true';
+      this.configService
+        .get<string>('CHATBOT_ENABLED', 'false')
+        .toLowerCase() === 'true';
   }
 
   public isChatbotJob(serviceName: string, methodName: string): boolean {

--- a/src/jobs/jobs.service.ts
+++ b/src/jobs/jobs.service.ts
@@ -2,11 +2,33 @@ import { join } from 'node:path';
 import { isMainThread, Worker } from 'node:worker_threads';
 
 import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { Cron, CronExpression, Timeout } from '@nestjs/schedule';
 
 @Injectable()
 export class JobsService {
   private readonly logger = new Logger(JobsService.name);
+  private readonly chatbotEnabled: boolean;
+
+  constructor(private readonly configService: ConfigService) {
+    this.chatbotEnabled =
+      this.configService.get<string>('CHATBOT_ENABLED', 'false').toLowerCase() ===
+      'true';
+  }
+
+  public isChatbotJob(serviceName: string, methodName: string): boolean {
+    return (
+      serviceName === 'CourseEmbeddingIndexerService' && methodName === 'run'
+    );
+  }
+
+  public canRunJob(serviceName: string, methodName: string): boolean {
+    if (!this.isChatbotJob(serviceName, methodName)) {
+      return true;
+    }
+
+    return this.chatbotEnabled;
+  }
 
   public runWorker<T>(serviceName: string, methodName: string): Promise<T> {
     return new Promise<T>((resolve, reject) => {
@@ -98,6 +120,13 @@ export class JobsService {
 
     for (const [index, job] of jobs.entries()) {
       const { service, method } = job;
+
+      if (!this.canRunJob(service, method)) {
+        this.logger.log(
+          `Skipping job ${index + 1}: ${service}.${method} because CHATBOT_ENABLED=false`
+        );
+        continue;
+      }
 
       try {
         this.logger.log(`Starting job ${index + 1}: ${service}.${method}`);

--- a/src/llm-generation/llm-generation.module.ts
+++ b/src/llm-generation/llm-generation.module.ts
@@ -1,13 +1,16 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 
+import { ChatbotEnabledGuard } from '../common/guards/chatbot-enabled.guard';
+import chatbotConfig from '../config/chatbot.config';
 import { EmbeddingModule } from '../embedding/embedding.module';
 import { LlmController } from './llm.controller';
 import { LlmService } from './llm.service';
 
 @Module({
-  imports: [EmbeddingModule],
+  imports: [EmbeddingModule, ConfigModule.forFeature(chatbotConfig)],
   controllers: [LlmController],
-  providers: [LlmService],
+  providers: [LlmService, ChatbotEnabledGuard],
   exports: [LlmService]
 })
 export class LlmGenerationModule {}

--- a/src/llm-generation/llm.controller.ts
+++ b/src/llm-generation/llm.controller.ts
@@ -1,4 +1,11 @@
-import { Body, Controller, Get, HttpCode, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  Post,
+  UseGuards
+} from '@nestjs/common';
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 
 import { ChatbotEnabledGuard } from '../common/guards/chatbot-enabled.guard';

--- a/src/llm-generation/llm.controller.ts
+++ b/src/llm-generation/llm.controller.ts
@@ -1,6 +1,7 @@
-import { Body, Controller, Get, HttpCode, Post } from '@nestjs/common';
+import { Body, Controller, Get, HttpCode, Post, UseGuards } from '@nestjs/common';
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 
+import { ChatbotEnabledGuard } from '../common/guards/chatbot-enabled.guard';
 import {
   GenerateDto,
   GenerateResponseDto,
@@ -10,6 +11,7 @@ import { LlmService } from './llm.service';
 
 @ApiTags('Chatbot')
 @Controller('chatbot')
+@UseGuards(ChatbotEnabledGuard)
 export class LlmController {
   constructor(private readonly llmService: LlmService) {}
 

--- a/test/app.controller.test.ts
+++ b/test/app.controller.test.ts
@@ -1,0 +1,365 @@
+import { HttpStatus } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import type { Response } from 'express';
+
+import { AppController } from '../src/app.controller';
+import { PrismaService } from '../src/prisma/prisma.service';
+
+describe('AppController', () => {
+  let controller: AppController;
+
+  const prisma = {
+    $queryRaw: jest.fn()
+  };
+
+  const originalEnv = {
+    FRONTEND_URL: process.env.FRONTEND_URL,
+    QDRANT_URL: process.env.QDRANT_URL
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    prisma.$queryRaw.mockResolvedValue([{ '?column?': 1 }]);
+
+    global.fetch = jest.fn().mockResolvedValue({
+      status: 200
+    }) as jest.Mock;
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AppController],
+      providers: [{ provide: PrismaService, useValue: prisma }]
+    }).compile();
+
+    controller = module.get<AppController>(AppController);
+  });
+
+  afterEach(() => {
+    if (originalEnv.FRONTEND_URL === undefined) {
+      delete process.env.FRONTEND_URL;
+    } else {
+      process.env.FRONTEND_URL = originalEnv.FRONTEND_URL;
+    }
+
+    if (originalEnv.QDRANT_URL === undefined) {
+      delete process.env.QDRANT_URL;
+    } else {
+      process.env.QDRANT_URL = originalEnv.QDRANT_URL;
+    }
+  });
+
+  it('should return hello world', () => {
+    expect(controller.getHello()).toBe('Hello World!');
+  });
+
+  it('should return liveness status', () => {
+    const result = controller.getLiveness();
+
+    expect(result).toEqual({
+      status: 'ok',
+      timestamp: expect.any(String)
+    });
+  });
+
+  it('should throw the monitoring test error', () => {
+    expect(() => controller.getError()).toThrow(
+      'Monitoring test error from /health/monitoring endpoint'
+    );
+  });
+
+  describe('healthCheck', () => {
+    it('should return ok when postgres, frontend, and qdrant are healthy', async () => {
+      process.env.FRONTEND_URL = 'https://frontend.example.com';
+      process.env.QDRANT_URL = 'https://qdrant.example.com';
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        status: 200
+      });
+
+      const result = await controller.healthCheck();
+
+      expect(result).toEqual({
+        status: 'ok',
+        timestamp: expect.any(String),
+        services: {
+          frontend: {
+            status: 'ok',
+            url: 'https://frontend.example.com/',
+            statusCode: 200,
+            latencyMs: expect.any(Number),
+            error: undefined
+          },
+          postgres: {
+            status: 'ok',
+            latencyMs: expect.any(Number)
+          },
+          qdrant: {
+            status: 'ok',
+            url: 'https://qdrant.example.com/healthz',
+            statusCode: 200,
+            latencyMs: expect.any(Number),
+            error: undefined
+          }
+        }
+      });
+
+      expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should return degraded when only the frontend is down', async () => {
+      process.env.FRONTEND_URL = 'https://frontend.example.com';
+      process.env.QDRANT_URL = 'https://qdrant.example.com';
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({
+          status: 500
+        })
+        .mockResolvedValueOnce({
+          status: 200
+        });
+
+      const result = await controller.healthCheck();
+
+      expect(result.status).toBe('degraded');
+      expect(result.services.frontend).toMatchObject({
+        status: 'down',
+        url: 'https://frontend.example.com/',
+        statusCode: 500,
+        error: 'Unexpected status code 500'
+      });
+      expect(result.services.qdrant.status).toBe('ok');
+      expect(result.services.postgres.status).toBe('ok');
+    });
+
+    it('should return error when qdrant is down', async () => {
+      process.env.FRONTEND_URL = 'https://frontend.example.com';
+      process.env.QDRANT_URL = 'https://qdrant.example.com';
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({
+          status: 200
+        })
+        .mockResolvedValueOnce({
+          status: 503
+        });
+
+      const result = await controller.healthCheck();
+
+      expect(result.status).toBe('error');
+      expect(result.services.qdrant).toMatchObject({
+        status: 'down',
+        url: 'https://qdrant.example.com/healthz',
+        statusCode: 503,
+        error: 'Unexpected status code 503'
+      });
+    });
+
+    it('should return error when postgres is down with an Error', async () => {
+      process.env.FRONTEND_URL = 'https://frontend.example.com';
+      process.env.QDRANT_URL = 'https://qdrant.example.com';
+
+      prisma.$queryRaw.mockRejectedValue(new Error('database unavailable'));
+
+      const result = await controller.healthCheck();
+
+      expect(result.status).toBe('error');
+      expect(result.services.postgres).toEqual({
+        status: 'down',
+        latencyMs: expect.any(Number),
+        error: 'database unavailable'
+      });
+    });
+
+    it('should return Unknown health check error when postgres throws a non-Error value', async () => {
+      process.env.FRONTEND_URL = 'https://frontend.example.com';
+      process.env.QDRANT_URL = 'https://qdrant.example.com';
+
+      prisma.$queryRaw.mockRejectedValue('database failed');
+
+      const result = await controller.healthCheck();
+
+      expect(result.status).toBe('error');
+      expect(result.services.postgres).toEqual({
+        status: 'down',
+        latencyMs: expect.any(Number),
+        error: 'Unknown health check error'
+      });
+    });
+
+    it('should return ok when frontend and qdrant are unconfigured and postgres is healthy', async () => {
+      delete process.env.FRONTEND_URL;
+      delete process.env.QDRANT_URL;
+
+      const result = await controller.healthCheck();
+
+      expect(result).toEqual({
+        status: 'ok',
+        timestamp: expect.any(String),
+        services: {
+          frontend: {
+            status: 'unconfigured'
+          },
+          postgres: {
+            status: 'ok',
+            latencyMs: expect.any(Number)
+          },
+          qdrant: {
+            status: 'unconfigured'
+          }
+        }
+      });
+
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should return down when an HTTP health check throws an Error', async () => {
+      process.env.FRONTEND_URL = 'https://frontend.example.com';
+      process.env.QDRANT_URL = 'https://qdrant.example.com';
+
+      (global.fetch as jest.Mock)
+        .mockRejectedValueOnce(new Error('frontend timeout'))
+        .mockResolvedValueOnce({
+          status: 200
+        });
+
+      const result = await controller.healthCheck();
+
+      expect(result.status).toBe('degraded');
+      expect(result.services.frontend).toEqual({
+        status: 'down',
+        url: 'https://frontend.example.com',
+        latencyMs: expect.any(Number),
+        error: 'frontend timeout'
+      });
+    });
+
+    it('should return Unknown health check error when an HTTP health check throws a non-Error value', async () => {
+      process.env.FRONTEND_URL = 'https://frontend.example.com';
+      process.env.QDRANT_URL = 'https://qdrant.example.com';
+
+      (global.fetch as jest.Mock)
+        .mockRejectedValueOnce('frontend failed')
+        .mockResolvedValueOnce({
+          status: 200
+        });
+
+      const result = await controller.healthCheck();
+
+      expect(result.status).toBe('degraded');
+      expect(result.services.frontend).toEqual({
+        status: 'down',
+        url: 'https://frontend.example.com',
+        latencyMs: expect.any(Number),
+        error: 'Unknown health check error'
+      });
+    });
+  });
+
+  describe('readinessCheck', () => {
+    function createResponseMock(): Response {
+      return {
+        status: jest.fn().mockReturnThis()
+      } as unknown as Response;
+    }
+
+    it('should return ok and HTTP 200 when postgres and qdrant are healthy', async () => {
+      process.env.QDRANT_URL = 'https://qdrant.example.com';
+
+      const response = createResponseMock();
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        status: 200
+      });
+
+      const result = await controller.readinessCheck(response);
+
+      expect(response.status).toHaveBeenCalledWith(HttpStatus.OK);
+      expect(result).toEqual({
+        status: 'ok',
+        timestamp: expect.any(String),
+        services: {
+          postgres: {
+            status: 'ok',
+            latencyMs: expect.any(Number)
+          },
+          qdrant: {
+            status: 'ok',
+            url: 'https://qdrant.example.com/healthz',
+            statusCode: 200,
+            latencyMs: expect.any(Number),
+            error: undefined
+          }
+        }
+      });
+    });
+
+    it('should return ok and HTTP 200 when qdrant is unconfigured', async () => {
+      delete process.env.QDRANT_URL;
+
+      const response = createResponseMock();
+
+      const result = await controller.readinessCheck(response);
+
+      expect(response.status).toHaveBeenCalledWith(HttpStatus.OK);
+      expect(result).toEqual({
+        status: 'ok',
+        timestamp: expect.any(String),
+        services: {
+          postgres: {
+            status: 'ok',
+            latencyMs: expect.any(Number)
+          },
+          qdrant: {
+            status: 'unconfigured'
+          }
+        }
+      });
+
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should return error and HTTP 503 when qdrant is down', async () => {
+      process.env.QDRANT_URL = 'https://qdrant.example.com';
+
+      const response = createResponseMock();
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        status: 500
+      });
+
+      const result = await controller.readinessCheck(response);
+
+      expect(response.status).toHaveBeenCalledWith(
+        HttpStatus.SERVICE_UNAVAILABLE
+      );
+      expect(result.status).toBe('error');
+      expect(result.services.qdrant).toMatchObject({
+        status: 'down',
+        url: 'https://qdrant.example.com/healthz',
+        statusCode: 500,
+        error: 'Unexpected status code 500'
+      });
+    });
+
+    it('should return error and HTTP 503 when postgres is down', async () => {
+      process.env.QDRANT_URL = 'https://qdrant.example.com';
+
+      const response = createResponseMock();
+
+      prisma.$queryRaw.mockRejectedValue(new Error('postgres down'));
+
+      const result = await controller.readinessCheck(response);
+
+      expect(response.status).toHaveBeenCalledWith(
+        HttpStatus.SERVICE_UNAVAILABLE
+      );
+      expect(result.status).toBe('error');
+      expect(result.services.postgres).toEqual({
+        status: 'down',
+        latencyMs: expect.any(Number),
+        error: 'postgres down'
+      });
+    });
+  });
+});

--- a/test/config/chatbot.config.test.ts
+++ b/test/config/chatbot.config.test.ts
@@ -1,0 +1,43 @@
+import chatbotConfig from '../../src/config/chatbot.config';
+
+describe('chatbot.config', () => {
+  const originalEnv = process.env.CHATBOT_ENABLED;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.CHATBOT_ENABLED;
+    } else {
+      process.env.CHATBOT_ENABLED = originalEnv;
+    }
+  });
+
+  it('should disable the chatbot by default when CHATBOT_ENABLED is not defined', () => {
+    delete process.env.CHATBOT_ENABLED;
+
+    expect(chatbotConfig()).toEqual({ enabled: false });
+  });
+
+  it('should disable the chatbot when CHATBOT_ENABLED=false', () => {
+    process.env.CHATBOT_ENABLED = 'false';
+
+    expect(chatbotConfig()).toEqual({ enabled: false });
+  });
+
+  it('should enable the chatbot when CHATBOT_ENABLED=true', () => {
+    process.env.CHATBOT_ENABLED = 'true';
+
+    expect(chatbotConfig()).toEqual({ enabled: true });
+  });
+
+  it('should enable the chatbot when CHATBOT_ENABLED=TRUE', () => {
+    process.env.CHATBOT_ENABLED = 'TRUE';
+
+    expect(chatbotConfig()).toEqual({ enabled: true });
+  });
+
+  it('should disable the chatbot for any value other than true', () => {
+    process.env.CHATBOT_ENABLED = 'yes';
+
+    expect(chatbotConfig()).toEqual({ enabled: false });
+  });
+});

--- a/test/jobs/jobs-scheduler.module.test.ts
+++ b/test/jobs/jobs-scheduler.module.test.ts
@@ -1,0 +1,18 @@
+import { MODULE_METADATA } from '@nestjs/common/constants';
+import { ScheduleModule } from '@nestjs/schedule';
+
+import { JobsModule } from '../../src/jobs/jobs.module';
+import { JobsSchedulerModule } from '../../src/jobs/jobs-scheduler.module';
+
+describe('JobsSchedulerModule', () => {
+  it('should import ScheduleModule.forRoot and JobsModule', () => {
+    const imports = Reflect.getMetadata(
+      MODULE_METADATA.IMPORTS,
+      JobsSchedulerModule
+    );
+
+    expect(imports).toHaveLength(2);
+    expect(imports[0]).toMatchObject({ module: ScheduleModule });
+    expect(imports[1]).toBe(JobsModule);
+  });
+});

--- a/test/jobs/jobs.constants.test.ts
+++ b/test/jobs/jobs.constants.test.ts
@@ -1,0 +1,47 @@
+import { Provider } from '@nestjs/common';
+
+import { CourseCodeValidationPipe } from '../../src/common/pipes/models/course/course-code-validation-pipe';
+import { CourseEmbeddingIndexerService } from '../../src/embedding/embedding-course-indexer.service';
+import {
+  jobWorkerProviders,
+  jobWorkerServiceMap
+} from '../../src/jobs/jobs.constants';
+import { CourseInstancesJobService } from '../../src/jobs/workers/course-instances.worker';
+import { CoursesJobService } from '../../src/jobs/workers/courses.worker';
+import { ProgramsJobService } from '../../src/jobs/workers/programs.worker';
+import { SessionsJobService } from '../../src/jobs/workers/sessions.worker';
+
+describe('jobs.constants', () => {
+  it('should expose all worker services in the worker service map', () => {
+    expect(jobWorkerServiceMap).toEqual({
+      ProgramsJobService,
+      CoursesJobService,
+      CourseInstancesJobService,
+      SessionsJobService,
+      CourseEmbeddingIndexerService
+    });
+  });
+
+  it('should expose the expected worker service names', () => {
+    expect(Object.keys(jobWorkerServiceMap)).toEqual([
+      'ProgramsJobService',
+      'CoursesJobService',
+      'CourseInstancesJobService',
+      'SessionsJobService',
+      'CourseEmbeddingIndexerService'
+    ]);
+  });
+
+  it('should register worker providers required by the worker module', () => {
+    expect(jobWorkerProviders).toEqual(
+      expect.arrayContaining<Provider>([
+        ProgramsJobService,
+        CoursesJobService,
+        CourseInstancesJobService,
+        SessionsJobService,
+        CourseEmbeddingIndexerService,
+        CourseCodeValidationPipe
+      ])
+    );
+  });
+});

--- a/test/jobs/jobs.constants.test.ts
+++ b/test/jobs/jobs.constants.test.ts
@@ -39,9 +39,12 @@ describe('jobs.constants', () => {
         CoursesJobService,
         CourseInstancesJobService,
         SessionsJobService,
-        CourseEmbeddingIndexerService,
         CourseCodeValidationPipe
       ])
     );
+  });
+
+  it('should not directly register CourseEmbeddingIndexerService in jobWorkerProviders', () => {
+    expect(jobWorkerProviders).not.toContain(CourseEmbeddingIndexerService);
   });
 });

--- a/test/jobs/jobs.controller.test.ts
+++ b/test/jobs/jobs.controller.test.ts
@@ -1,0 +1,280 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { RunWorkersDto } from '../../src/jobs/dtos/run-workers.dto';
+import { JobsController } from '../../src/jobs/jobs.controller';
+import { JobsService } from '../../src/jobs/jobs.service';
+
+describe('JobsController', () => {
+  let controller: JobsController;
+
+  const jobsService = {
+    processJobs: jest.fn(),
+    runWorker: jest.fn(),
+    canRunJob: jest.fn()
+  };
+
+  const buildRunWorkersDto = (
+    overrides: Partial<RunWorkersDto> = {}
+  ): RunWorkersDto => ({
+    processAllJobs: false,
+    processPrograms: false,
+    processCourses: false,
+    processCourseDescriptions: false,
+    processCourseInstances: false,
+    processProgramCourses: false,
+    processSessions: false,
+    processCourseEmbeddings: false,
+    ...overrides
+  });
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    jobsService.processJobs.mockResolvedValue(undefined);
+    jobsService.runWorker.mockResolvedValue({ status: 'ok' });
+    jobsService.canRunJob.mockReturnValue(true);
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [JobsController],
+      providers: [{ provide: JobsService, useValue: jobsService }]
+    }).compile();
+
+    controller = module.get<JobsController>(JobsController);
+  });
+
+  it('should trigger all jobs when processAllJobs=true', async () => {
+    const result = await controller.runWorkers(
+      buildRunWorkersDto({ processAllJobs: true })
+    );
+
+    expect(jobsService.processJobs).toHaveBeenCalledTimes(1);
+    expect(jobsService.runWorker).not.toHaveBeenCalled();
+    expect(result).toEqual({ status: 'All jobs have been triggered' });
+  });
+
+  it('should trigger all jobs when body is undefined because processAllJobs defaults to true', async () => {
+    const result = await controller.runWorkers(
+      undefined as unknown as RunWorkersDto
+    );
+
+    expect(jobsService.processJobs).toHaveBeenCalledTimes(1);
+    expect(jobsService.runWorker).not.toHaveBeenCalled();
+    expect(result).toEqual({ status: 'All jobs have been triggered' });
+  });
+
+  it('should return no jobs triggered when processAllJobs=false and no flags are set', async () => {
+    const result = await controller.runWorkers(buildRunWorkersDto());
+
+    expect(jobsService.processJobs).not.toHaveBeenCalled();
+    expect(jobsService.runWorker).not.toHaveBeenCalled();
+    expect(result).toEqual({ status: 'No jobs triggered (no flags set)' });
+  });
+
+  it('should map all selected flags to their jobs and run them successfully', async () => {
+    const result = await controller.runWorkers(
+      buildRunWorkersDto({
+        processPrograms: true,
+        processCourses: true,
+        processCourseDescriptions: true,
+        processCourseInstances: true,
+        processProgramCourses: true,
+        processSessions: true,
+        processCourseEmbeddings: true
+      })
+    );
+
+    expect(jobsService.runWorker).toHaveBeenCalledTimes(7);
+    expect(jobsService.runWorker).toHaveBeenNthCalledWith(
+      1,
+      'ProgramsJobService',
+      'processPrograms'
+    );
+    expect(jobsService.runWorker).toHaveBeenNthCalledWith(
+      2,
+      'CoursesJobService',
+      'processCourses'
+    );
+    expect(jobsService.runWorker).toHaveBeenNthCalledWith(
+      3,
+      'CoursesJobService',
+      'syncCourseDescriptionsFromEtsWebsite'
+    );
+    expect(jobsService.runWorker).toHaveBeenNthCalledWith(
+      4,
+      'CourseInstancesJobService',
+      'processCourseInstances'
+    );
+    expect(jobsService.runWorker).toHaveBeenNthCalledWith(
+      5,
+      'CoursesJobService',
+      'syncCourseDetailsWithCheminotData'
+    );
+    expect(jobsService.runWorker).toHaveBeenNthCalledWith(
+      6,
+      'SessionsJobService',
+      'processSessions'
+    );
+    expect(jobsService.runWorker).toHaveBeenNthCalledWith(
+      7,
+      'CourseEmbeddingIndexerService',
+      'run'
+    );
+
+    expect(result).toEqual({
+      status: 'Selected jobs processed',
+      results: [
+        {
+          job: { service: 'ProgramsJobService', method: 'processPrograms' },
+          status: 'success'
+        },
+        {
+          job: { service: 'CoursesJobService', method: 'processCourses' },
+          status: 'success'
+        },
+        {
+          job: {
+            service: 'CoursesJobService',
+            method: 'syncCourseDescriptionsFromEtsWebsite'
+          },
+          status: 'success'
+        },
+        {
+          job: {
+            service: 'CourseInstancesJobService',
+            method: 'processCourseInstances'
+          },
+          status: 'success'
+        },
+        {
+          job: {
+            service: 'CoursesJobService',
+            method: 'syncCourseDetailsWithCheminotData'
+          },
+          status: 'success'
+        },
+        {
+          job: { service: 'SessionsJobService', method: 'processSessions' },
+          status: 'success'
+        },
+        {
+          job: {
+            service: 'CourseEmbeddingIndexerService',
+            method: 'run'
+          },
+          status: 'success'
+        }
+      ]
+    });
+  });
+
+  it('should skip a selected job when JobsService.canRunJob returns false', async () => {
+    jobsService.canRunJob.mockImplementation(
+      (service: string, method: string) =>
+        !(service === 'CourseEmbeddingIndexerService' && method === 'run')
+    );
+
+    const result = await controller.runWorkers(
+      buildRunWorkersDto({
+        processCourseEmbeddings: true
+      })
+    );
+
+    expect(jobsService.runWorker).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      status: 'Selected jobs processed',
+      results: [
+        {
+          job: {
+            service: 'CourseEmbeddingIndexerService',
+            method: 'run'
+          },
+          status: 'skipped',
+          reason: 'CHATBOT_ENABLED=false'
+        }
+      ]
+    });
+  });
+
+  it('should return an error result when a selected job fails with an Error', async () => {
+    jobsService.runWorker.mockRejectedValue(new Error('worker failed'));
+
+    const result = await controller.runWorkers(
+      buildRunWorkersDto({
+        processCourses: true
+      })
+    );
+
+    expect(result).toEqual({
+      status: 'Selected jobs processed',
+      results: [
+        {
+          job: {
+            service: 'CoursesJobService',
+            method: 'processCourses'
+          },
+          status: 'error',
+          error: 'worker failed'
+        }
+      ]
+    });
+  });
+
+  it('should return an error result when a selected job fails with a non-Error value', async () => {
+    jobsService.runWorker.mockRejectedValue('worker failed');
+
+    const result = await controller.runWorkers(
+      buildRunWorkersDto({
+        processCourses: true
+      })
+    );
+
+    expect(result).toEqual({
+      status: 'Selected jobs processed',
+      results: [
+        {
+          job: {
+            service: 'CoursesJobService',
+            method: 'processCourses'
+          },
+          status: 'error',
+          error: 'worker failed'
+        }
+      ]
+    });
+  });
+
+  it('should continue processing remaining selected jobs after one fails', async () => {
+    jobsService.runWorker
+      .mockRejectedValueOnce(new Error('first failed'))
+      .mockResolvedValueOnce({ status: 'ok' });
+
+    const result = await controller.runWorkers(
+      buildRunWorkersDto({
+        processPrograms: true,
+        processCourses: true
+      })
+    );
+
+    expect(jobsService.runWorker).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({
+      status: 'Selected jobs processed',
+      results: [
+        {
+          job: {
+            service: 'ProgramsJobService',
+            method: 'processPrograms'
+          },
+          status: 'error',
+          error: 'first failed'
+        },
+        {
+          job: {
+            service: 'CoursesJobService',
+            method: 'processCourses'
+          },
+          status: 'success'
+        }
+      ]
+    });
+  });
+});

--- a/test/jobs/jobs.service.test.ts
+++ b/test/jobs/jobs.service.test.ts
@@ -233,15 +233,15 @@ describe('JobsService', () => {
   });
 
   it('should identify the chatbot embedding job', () => {
-    expect(
-      service.isChatbotJob('CourseEmbeddingIndexerService', 'run')
-    ).toBe(true);
+    expect(service.isChatbotJob('CourseEmbeddingIndexerService', 'run')).toBe(
+      true
+    );
   });
 
   it('should not identify other jobs as chatbot jobs', () => {
-    expect(
-      service.isChatbotJob('ProgramsJobService', 'processPrograms')
-    ).toBe(false);
+    expect(service.isChatbotJob('ProgramsJobService', 'processPrograms')).toBe(
+      false
+    );
     expect(
       service.isChatbotJob('CourseEmbeddingIndexerService', 'otherMethod')
     ).toBe(false);
@@ -250,33 +250,33 @@ describe('JobsService', () => {
   it('should allow non-chatbot jobs when CHATBOT_ENABLED=false', async () => {
     await createService('false');
 
-    expect(
-      service.canRunJob('ProgramsJobService', 'processPrograms')
-    ).toBe(true);
+    expect(service.canRunJob('ProgramsJobService', 'processPrograms')).toBe(
+      true
+    );
   });
 
   it('should block the course embedding job when CHATBOT_ENABLED=false', async () => {
     await createService('false');
 
-    expect(
-      service.canRunJob('CourseEmbeddingIndexerService', 'run')
-    ).toBe(false);
+    expect(service.canRunJob('CourseEmbeddingIndexerService', 'run')).toBe(
+      false
+    );
   });
 
   it('should allow the course embedding job when CHATBOT_ENABLED=true', async () => {
     await createService('true');
 
-    expect(
-      service.canRunJob('CourseEmbeddingIndexerService', 'run')
-    ).toBe(true);
+    expect(service.canRunJob('CourseEmbeddingIndexerService', 'run')).toBe(
+      true
+    );
   });
 
   it('should allow the course embedding job when CHATBOT_ENABLED has uppercase TRUE', async () => {
     await createService('TRUE');
 
-    expect(
-      service.canRunJob('CourseEmbeddingIndexerService', 'run')
-    ).toBe(true);
+    expect(service.canRunJob('CourseEmbeddingIndexerService', 'run')).toBe(
+      true
+    );
   });
 
   it('should skip CourseEmbeddingIndexerService.run during processJobs when CHATBOT_ENABLED=false', async () => {

--- a/test/jobs/jobs.service.test.ts
+++ b/test/jobs/jobs.service.test.ts
@@ -39,7 +39,7 @@ describe('JobsService', () => {
 
   const WorkerMock = Worker as unknown as jest.Mock;
 
-  async function createService(chatbotEnabled = 'true'): Promise<void> {
+  async function createService(chatbotEnabled = true): Promise<void> {
     fakeWorkers = [];
 
     WorkerMock.mockImplementation((script: string, options: unknown) => {
@@ -54,7 +54,13 @@ describe('JobsService', () => {
         {
           provide: ConfigService,
           useValue: {
-            get: jest.fn().mockReturnValue(chatbotEnabled)
+            get: jest.fn((key: string, defaultValue?: unknown) => {
+              if (key === 'chatbot.enabled') {
+                return chatbotEnabled;
+              }
+
+              return defaultValue;
+            })
           }
         }
       ]
@@ -87,7 +93,7 @@ describe('JobsService', () => {
   beforeEach(async () => {
     jest.clearAllMocks();
     WorkerMock.mockReset();
-    await createService('true');
+    await createService(true);
   });
 
   afterEach(() => {
@@ -248,7 +254,7 @@ describe('JobsService', () => {
   });
 
   it('should allow non-chatbot jobs when CHATBOT_ENABLED=false', async () => {
-    await createService('false');
+    await createService(false);
 
     expect(service.canRunJob('ProgramsJobService', 'processPrograms')).toBe(
       true
@@ -256,7 +262,7 @@ describe('JobsService', () => {
   });
 
   it('should block the course embedding job when CHATBOT_ENABLED=false', async () => {
-    await createService('false');
+    await createService(false);
 
     expect(service.canRunJob('CourseEmbeddingIndexerService', 'run')).toBe(
       false
@@ -264,7 +270,7 @@ describe('JobsService', () => {
   });
 
   it('should allow the course embedding job when CHATBOT_ENABLED=true', async () => {
-    await createService('true');
+    await createService(true);
 
     expect(service.canRunJob('CourseEmbeddingIndexerService', 'run')).toBe(
       true
@@ -272,7 +278,7 @@ describe('JobsService', () => {
   });
 
   it('should allow the course embedding job when CHATBOT_ENABLED has uppercase TRUE', async () => {
-    await createService('TRUE');
+    await createService(true);
 
     expect(service.canRunJob('CourseEmbeddingIndexerService', 'run')).toBe(
       true
@@ -280,7 +286,7 @@ describe('JobsService', () => {
   });
 
   it('should skip CourseEmbeddingIndexerService.run during processJobs when CHATBOT_ENABLED=false', async () => {
-    await createService('false');
+    await createService(false);
 
     runWorkerSpy.mockResolvedValue({ status: 'ok' });
 

--- a/test/jobs/jobs.service.test.ts
+++ b/test/jobs/jobs.service.test.ts
@@ -1,35 +1,106 @@
+import { Worker } from 'node:worker_threads';
+
+import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { JobsService } from '../../src/jobs/jobs.service';
+
+jest.mock('node:worker_threads', () => ({
+  isMainThread: true,
+  Worker: jest.fn()
+}));
+
+class FakeWorker {
+  private readonly handlers = new Map<string, (payload: unknown) => void>();
+
+  constructor(
+    public readonly script: string,
+    public readonly options: unknown
+  ) {}
+
+  public on(event: string, handler: (payload: unknown) => void): FakeWorker {
+    this.handlers.set(event, handler);
+    return this;
+  }
+
+  public emit(event: string, payload: unknown): void {
+    this.handlers.get(event)?.(payload);
+  }
+}
 
 describe('JobsService', () => {
   let service: JobsService;
   let runWorkerSpy: jest.SpyInstance;
   let loggerLogSpy: jest.SpyInstance;
+  let loggerDebugSpy: jest.SpyInstance;
   let loggerErrorSpy: jest.SpyInstance;
+  let loggerVerboseSpy: jest.SpyInstance;
+  let fakeWorkers: FakeWorker[];
 
-  beforeEach(async () => {
-    jest.clearAllMocks();
+  const WorkerMock = Worker as unknown as jest.Mock;
+
+  async function createService(chatbotEnabled = 'true'): Promise<void> {
+    fakeWorkers = [];
+
+    WorkerMock.mockImplementation((script: string, options: unknown) => {
+      const worker = new FakeWorker(script, options);
+      fakeWorkers.push(worker);
+      return worker;
+    });
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [JobsService]
+      providers: [
+        JobsService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn().mockReturnValue(chatbotEnabled)
+          }
+        }
+      ]
     }).compile();
+
     service = module.get<JobsService>(JobsService);
+
     runWorkerSpy = jest.spyOn(
       service as unknown as { runWorker: JobsService['runWorker'] },
       'runWorker'
     );
+
     loggerLogSpy = jest
       .spyOn(service['logger'], 'log')
       .mockImplementation(() => {});
+
+    loggerDebugSpy = jest
+      .spyOn(service['logger'], 'debug')
+      .mockImplementation(() => {});
+
     loggerErrorSpy = jest
       .spyOn(service['logger'], 'error')
       .mockImplementation(() => {});
+
+    loggerVerboseSpy = jest
+      .spyOn(service['logger'], 'verbose')
+      .mockImplementation(() => {});
+  }
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    WorkerMock.mockReset();
+    await createService('true');
+  });
+
+  afterEach(() => {
+    delete process.env.APP_ENV;
   });
 
   it('should process all jobs in order and call runWorker with correct service/method', async () => {
     const results = ['A', 'B', 'C', 'D', 'E', 'F', 'G'];
+
     runWorkerSpy.mockImplementation(() => Promise.resolve(results.shift()));
+
     await service.processJobs();
+
     expect(runWorkerSpy).toHaveBeenCalledTimes(7);
     expect(runWorkerSpy).toHaveBeenNthCalledWith(
       1,
@@ -68,7 +139,7 @@ describe('JobsService', () => {
     );
   });
 
-  it('should continue processing jobs even if one fails', async () => {
+  it('should continue processing jobs even if one fails with an Error', async () => {
     runWorkerSpy
       .mockResolvedValueOnce('ok1')
       .mockRejectedValueOnce(new Error('fail2'))
@@ -77,7 +148,9 @@ describe('JobsService', () => {
       .mockResolvedValueOnce('ok5')
       .mockResolvedValueOnce('ok6')
       .mockResolvedValueOnce('ok7');
+
     await service.processJobs();
+
     expect(runWorkerSpy).toHaveBeenCalledTimes(7);
     expect(loggerErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining(
@@ -87,7 +160,25 @@ describe('JobsService', () => {
     );
   });
 
-  it('should log job start, success, failure, and completion', async () => {
+  it('should continue processing jobs even if one fails with a non-Error value', async () => {
+    runWorkerSpy
+      .mockResolvedValueOnce('ok1')
+      .mockRejectedValueOnce('fail2')
+      .mockResolvedValueOnce('ok3')
+      .mockResolvedValueOnce('ok4')
+      .mockResolvedValueOnce('ok5')
+      .mockResolvedValueOnce('ok6')
+      .mockResolvedValueOnce('ok7');
+
+    await service.processJobs();
+
+    expect(runWorkerSpy).toHaveBeenCalledTimes(7);
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      'Job 2 (CoursesJobService.processCourses) failed: fail2'
+    );
+  });
+
+  it('should log job start, success, failure, debug, and completion', async () => {
     runWorkerSpy
       .mockResolvedValueOnce('ok1')
       .mockRejectedValueOnce(new Error('fail2'))
@@ -96,9 +187,15 @@ describe('JobsService', () => {
       .mockResolvedValueOnce('ok5')
       .mockResolvedValueOnce('ok6')
       .mockResolvedValueOnce('ok7');
+
     await service.processJobs();
+
     expect(loggerLogSpy).toHaveBeenCalledWith(
       'Starting sequential job processing...'
+    );
+    expect(loggerDebugSpy).toHaveBeenCalledWith(
+      'Are we on the main thread?',
+      'Yes'
     );
     expect(loggerLogSpy).toHaveBeenCalledWith(
       'Starting job 1: ProgramsJobService.processPrograms'
@@ -132,6 +229,170 @@ describe('JobsService', () => {
         'Job 2 (CoursesJobService.processCourses) failed: fail2'
       ),
       expect.any(String)
+    );
+  });
+
+  it('should identify the chatbot embedding job', () => {
+    expect(
+      service.isChatbotJob('CourseEmbeddingIndexerService', 'run')
+    ).toBe(true);
+  });
+
+  it('should not identify other jobs as chatbot jobs', () => {
+    expect(
+      service.isChatbotJob('ProgramsJobService', 'processPrograms')
+    ).toBe(false);
+    expect(
+      service.isChatbotJob('CourseEmbeddingIndexerService', 'otherMethod')
+    ).toBe(false);
+  });
+
+  it('should allow non-chatbot jobs when CHATBOT_ENABLED=false', async () => {
+    await createService('false');
+
+    expect(
+      service.canRunJob('ProgramsJobService', 'processPrograms')
+    ).toBe(true);
+  });
+
+  it('should block the course embedding job when CHATBOT_ENABLED=false', async () => {
+    await createService('false');
+
+    expect(
+      service.canRunJob('CourseEmbeddingIndexerService', 'run')
+    ).toBe(false);
+  });
+
+  it('should allow the course embedding job when CHATBOT_ENABLED=true', async () => {
+    await createService('true');
+
+    expect(
+      service.canRunJob('CourseEmbeddingIndexerService', 'run')
+    ).toBe(true);
+  });
+
+  it('should allow the course embedding job when CHATBOT_ENABLED has uppercase TRUE', async () => {
+    await createService('TRUE');
+
+    expect(
+      service.canRunJob('CourseEmbeddingIndexerService', 'run')
+    ).toBe(true);
+  });
+
+  it('should skip CourseEmbeddingIndexerService.run during processJobs when CHATBOT_ENABLED=false', async () => {
+    await createService('false');
+
+    runWorkerSpy.mockResolvedValue({ status: 'ok' });
+
+    await service.processJobs();
+
+    expect(runWorkerSpy).toHaveBeenCalledTimes(6);
+    expect(runWorkerSpy).not.toHaveBeenCalledWith(
+      'CourseEmbeddingIndexerService',
+      'run'
+    );
+
+    expect(runWorkerSpy).toHaveBeenCalledWith(
+      'ProgramsJobService',
+      'processPrograms'
+    );
+    expect(runWorkerSpy).toHaveBeenCalledWith(
+      'SessionsJobService',
+      'processSessions'
+    );
+
+    expect(loggerLogSpy).toHaveBeenCalledWith(
+      'Skipping job 7: CourseEmbeddingIndexerService.run because CHATBOT_ENABLED=false'
+    );
+  });
+
+  it('should not run boot-time jobs outside production', async () => {
+    process.env.APP_ENV = 'development';
+
+    const processJobsSpy = jest
+      .spyOn(service, 'processJobs')
+      .mockResolvedValue(undefined);
+
+    await service.runOnceAfterBoot();
+
+    expect(processJobsSpy).not.toHaveBeenCalled();
+  });
+
+  it('should run boot-time jobs in production', async () => {
+    process.env.APP_ENV = 'production';
+
+    const processJobsSpy = jest
+      .spyOn(service, 'processJobs')
+      .mockResolvedValue(undefined);
+
+    await service.runOnceAfterBoot();
+
+    expect(loggerLogSpy).toHaveBeenCalledWith('Boot-time job triggered...');
+    expect(processJobsSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should spawn a worker and resolve when the worker sends a message', async () => {
+    runWorkerSpy.mockRestore();
+
+    const promise = service.runWorker('ProgramsJobService', 'processPrograms');
+
+    expect(WorkerMock).toHaveBeenCalledTimes(1);
+    expect(fakeWorkers).toHaveLength(1);
+    expect(fakeWorkers[0].script).toContain('jobRunner.worker.js');
+    expect(fakeWorkers[0].options).toEqual({
+      workerData: {
+        serviceName: 'ProgramsJobService',
+        methodName: 'processPrograms'
+      }
+    });
+
+    fakeWorkers[0].emit('message', { status: 'ok' });
+    fakeWorkers[0].emit('exit', 0);
+
+    await expect(promise).resolves.toEqual({ status: 'ok' });
+    expect(loggerVerboseSpy).toHaveBeenCalledWith('Worker message:', {
+      status: 'ok'
+    });
+  });
+
+  it('should reject when the worker emits an Error', async () => {
+    runWorkerSpy.mockRestore();
+
+    const promise = service.runWorker('CoursesJobService', 'processCourses');
+
+    fakeWorkers[0].emit('error', new Error('worker failed'));
+
+    await expect(promise).rejects.toThrow('worker failed');
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      'Worker error:',
+      expect.any(Error)
+    );
+  });
+
+  it('should reject when the worker emits a non-Error value', async () => {
+    runWorkerSpy.mockRestore();
+
+    const promise = service.runWorker('CoursesJobService', 'processCourses');
+
+    fakeWorkers[0].emit('error', 'worker failed');
+
+    await expect(promise).rejects.toThrow('worker failed');
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      'Worker error:',
+      'worker failed'
+    );
+  });
+
+  it('should reject when the worker exits with a non-zero code', async () => {
+    runWorkerSpy.mockRestore();
+
+    const promise = service.runWorker('CoursesJobService', 'processCourses');
+
+    fakeWorkers[0].emit('exit', 1);
+
+    await expect(promise).rejects.toThrow('Worker stopped with exit code 1');
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      'Worker stopped with exit code 1'
     );
   });
 });

--- a/test/llm-generation/llm.controller.test.ts
+++ b/test/llm-generation/llm.controller.test.ts
@@ -2,35 +2,48 @@ import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import request from 'supertest';
 
+import chatbotConfig from '../../src/config/chatbot.config';
 import { LlmExhaustedException } from '../../src/llm-generation/exceptions/llm-exhausted.exception';
 import { LlmController } from '../../src/llm-generation/llm.controller';
 import { LlmService } from '../../src/llm-generation/llm.service';
 
 describe('LlmController', () => {
   let app: INestApplication;
+
   const llmService = {
     checkStatus: jest.fn(),
     recommend: jest.fn()
   };
 
-  beforeEach(async () => {
+  async function createApp(chatbotEnabled = true): Promise<void> {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [LlmController],
-      providers: [{ provide: LlmService, useValue: llmService }]
+      providers: [
+        { provide: LlmService, useValue: llmService },
+        {
+          provide: chatbotConfig.KEY,
+          useValue: { enabled: chatbotEnabled }
+        }
+      ]
     }).compile();
 
     app = module.createNestApplication();
     app.useGlobalPipes(new ValidationPipe());
     await app.init();
-  });
+  }
 
   afterEach(async () => {
     jest.clearAllMocks();
-    await app.close();
+
+    if (app) {
+      await app.close();
+    }
   });
 
   describe('GET /chatbot/status', () => {
     it('returns the list of provider statuses', async () => {
+      await createApp(true);
+
       const statuses = [
         { name: 'Groq (llama-3.3)', status: 'ok', latencyMs: 123 },
         {
@@ -40,6 +53,7 @@ describe('LlmController', () => {
           error: 'timeout'
         }
       ];
+
       llmService.checkStatus.mockResolvedValue(statuses);
 
       const { status, body } = await request(app.getHttpServer()).get(
@@ -51,20 +65,36 @@ describe('LlmController', () => {
     });
 
     it('calls LlmService.checkStatus once', async () => {
+      await createApp(true);
+
       llmService.checkStatus.mockResolvedValue([]);
 
       await request(app.getHttpServer()).get('/chatbot/status');
 
       expect(llmService.checkStatus).toHaveBeenCalledTimes(1);
     });
+
+    it('returns 404 when CHATBOT_ENABLED=false', async () => {
+      await createApp(false);
+
+      const { status } = await request(app.getHttpServer()).get(
+        '/chatbot/status'
+      );
+
+      expect(status).toBe(404);
+      expect(llmService.checkStatus).not.toHaveBeenCalled();
+    });
   });
 
   describe('POST /chatbot/recommend', () => {
     it('returns 200 with the LLM generation result', async () => {
+      await createApp(true);
+
       const response = {
         courses: [{ code: 'LOG121' }],
         explanation: 'Great choice.'
       };
+
       llmService.recommend.mockResolvedValue(response);
 
       const { status, body } = await request(app.getHttpServer())
@@ -77,6 +107,8 @@ describe('LlmController', () => {
     });
 
     it('returns 400 when the prompt field is missing', async () => {
+      await createApp(true);
+
       const { status } = await request(app.getHttpServer())
         .post('/chatbot/recommend')
         .send({});
@@ -86,6 +118,8 @@ describe('LlmController', () => {
     });
 
     it('returns 400 when the prompt is an empty string', async () => {
+      await createApp(true);
+
       const { status } = await request(app.getHttpServer())
         .post('/chatbot/recommend')
         .send({ prompt: '' });
@@ -95,6 +129,8 @@ describe('LlmController', () => {
     });
 
     it('returns 400 when the prompt is not a string', async () => {
+      await createApp(true);
+
       const { status } = await request(app.getHttpServer())
         .post('/chatbot/recommend')
         .send({ prompt: 42 });
@@ -104,6 +140,8 @@ describe('LlmController', () => {
     });
 
     it('returns 500 when all LLM providers are exhausted', async () => {
+      await createApp(true);
+
       llmService.recommend.mockRejectedValue(new LlmExhaustedException());
 
       const { status } = await request(app.getHttpServer())
@@ -111,6 +149,17 @@ describe('LlmController', () => {
         .send({ prompt: 'I want to learn AI' });
 
       expect(status).toBe(500);
+    });
+
+    it('returns 404 when CHATBOT_ENABLED=false', async () => {
+      await createApp(false);
+
+      const { status } = await request(app.getHttpServer())
+        .post('/chatbot/recommend')
+        .send({ prompt: 'I want to learn AI' });
+
+      expect(status).toBe(404);
+      expect(llmService.recommend).not.toHaveBeenCalled();
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1168,6 +1168,15 @@
     iterare "1.2.1"
     tslib "2.8.1"
 
+"@nestjs/config@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@nestjs/config/-/config-4.0.4.tgz#311d806fdc32a8bf29cf9ced903b97cbdb7e064b"
+  integrity sha512-CJPjNitr0bAufSEnRe2N+JbnVmMmDoo6hvKCPzXgZoGwJSmp/dZPk9f/RMbuD/+Q1ZJPjwsRpq0vxna++Knwow==
+  dependencies:
+    dotenv "17.4.1"
+    dotenv-expand "12.0.3"
+    lodash "4.18.1"
+
 "@nestjs/core@^10.4.10":
   version "10.4.20"
   resolved "https://registry.yarnpkg.com/@nestjs/core/-/core-10.4.20.tgz#2740b91f60b5b3896e3bca5a189064e7bc15c2fc"
@@ -3489,6 +3498,23 @@ domutils@^3.0.1, domutils@^3.2.2:
     domelementtype "^2.3.0"
     domhandler "^5.0.3"
 
+dotenv-expand@12.0.3:
+  version "12.0.3"
+  resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-12.0.3.tgz#6323ceca51ca0c1b1f0055e2aba39c79781739a6"
+  integrity sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==
+  dependencies:
+    dotenv "^16.4.5"
+
+dotenv@17.4.1:
+  version "17.4.1"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-17.4.1.tgz#d8e2179fe287365ef3aecb9459668454168eda88"
+  integrity sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==
+
+dotenv@^16.4.5:
+  version "16.6.1"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.6.1.tgz#773f0e69527a8315c7285d5ee73c4459d20a8020"
+  integrity sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==
+
 dotenv@^17.2.3:
   version "17.2.3"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-17.2.3.tgz#ad995d6997f639b11065f419a22fabf567cdb9a2"
@@ -5643,7 +5669,7 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@4.17.23, lodash@4.18.0, lodash@^4.17.21:
+lodash@4.17.23, lodash@4.18.0, lodash@4.18.1, lodash@^4.17.21:
   version "4.18.0"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.0.tgz#dfd726f07ab2e39dd763de28fcf66e395c03e440"
   integrity sha512-l1mfj2atMqndAHI3ls7XqPxEjV2J9ZkcNyHpoZA3r2T1LLwDB69jgkMWh71YKwhBbK0G2f4WSn05ahmQXVxupA==


### PR DESCRIPTION
### ⁉️ Related Issue
closes #116 

## 📖 Description
This PR adds a feature toggle to disable the chatbot in environments where it should not be exposed yet.

The backend now reads the `CHATBOT_ENABLED` environment variable at startup. When the variable is set to `false`, chatbot-related routes return `404` and the chatbot embedding/indexing job is skipped. This allows the chatbot to stay enabled in development and staging while remaining hidden in production.

Main changes:
- Added `CHATBOT_ENABLED` configuration.
- Added a chatbot guard to block chatbot routes when disabled.
- Applied the guard to chatbot-related controllers.
- Updated jobs logic to skip `CourseEmbeddingIndexerService.run` when the chatbot is disabled.
- Updated environment configuration so: `CHATBOT_ENABLED=false`
- Added and updated unit tests for the feature toggle, chatbot routes, jobs service, jobs controller, and config behavior.


### 🧪 How Has This Been Tested?
Additionnal unit test

### ☑️ Checklist before requesting a review
- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

### 🖼️ Screenshots (if useful)
<img width="2267" height="1307" alt="image" src="https://github.com/user-attachments/assets/c4abcd9d-7290-43ef-8fc6-835a0600004d" />
<img width="757" height="314" alt="image" src="https://github.com/user-attachments/assets/46d5b69d-34cb-4eed-bd3c-f7bc60371fcc" />