### PR TITLE
feat: implement streaming course recommendations via SSE

### DIFF
--- a/src/common/exceptions/http-exception.filter.ts
+++ b/src/common/exceptions/http-exception.filter.ts
@@ -9,6 +9,8 @@ import { Request, Response } from 'express';
 
 import { PosthogMonitoringService } from '@/monitoring/posthog-monitoring.service';
 
+import { extractHttpExceptionMessage } from '../utils/error/errorUtil';
+
 @Catch(HttpException)
 export class HttpExceptionFilter implements ExceptionFilter {
   private readonly logger = new Logger(HttpExceptionFilter.name);
@@ -52,7 +54,7 @@ export class HttpExceptionFilter implements ExceptionFilter {
       statusCode: status,
       timestamp: new Date().toISOString(),
       path: request.url,
-      message: exception.message || 'Internal Server Error'
+      message: extractHttpExceptionMessage(exception)
     });
   }
 }

--- a/src/common/utils/error/error-constants.ts
+++ b/src/common/utils/error/error-constants.ts
@@ -26,3 +26,10 @@ export class FileExtractionError extends Error {
     this.name = 'FileExtractionError';
   }
 }
+
+/*
+ * Errors related to the chatbot
+ */
+
+export const CHATBOT_ERROR_PROMPT_BLANK =
+  'PROMPT_EMPTY_OR_CONTAINS_ONLY_WHITESPACES';

--- a/src/common/utils/error/errorUtil.ts
+++ b/src/common/utils/error/errorUtil.ts
@@ -11,7 +11,10 @@ export function isAxiosError(error: unknown): error is AxiosError {
 }
 
 export function extractHttpExceptionMessage(exception: HttpException): string {
-  const body = exception.getResponse();
+  const body =
+    typeof exception.getResponse === 'function'
+      ? exception.getResponse()
+      : undefined;
 
   if (typeof body === 'string') {
     return body;

--- a/src/common/utils/error/errorUtil.ts
+++ b/src/common/utils/error/errorUtil.ts
@@ -1,3 +1,4 @@
+import { HttpException } from '@nestjs/common';
 import { AxiosError } from 'axios';
 
 export function isAxiosError(error: unknown): error is AxiosError {
@@ -7,4 +8,22 @@ export function isAxiosError(error: unknown): error is AxiosError {
     'isAxiosError' in error &&
     (error as Record<string, unknown>).isAxiosError === true
   );
+}
+
+export function extractHttpExceptionMessage(exception: HttpException): string {
+  const body = exception.getResponse();
+
+  if (typeof body === 'string') {
+    return body;
+  }
+
+  const message = (body as { message?: string | string[] })?.message;
+  if (Array.isArray(message)) {
+    return message[0] ?? exception.message;
+  }
+  if (typeof message === 'string') {
+    return message;
+  }
+
+  return exception.message || 'Internal Server Error';
 }

--- a/src/course/course.controller.ts
+++ b/src/course/course.controller.ts
@@ -111,6 +111,7 @@ export class CourseController {
   }
 
   @Get(':id')
+  @ApiOperation({ summary: '🟢 Get course by ID' })
   @ApiOkResponse({ type: CourseDto })
   public getCourse(@Param('id', ParseIntPipe) id: number) {
     return this.courseService.getCourse({ id });

--- a/src/llm-generation/dtos/generate.dto.ts
+++ b/src/llm-generation/dtos/generate.dto.ts
@@ -1,14 +1,49 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsArray,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Matches
+} from 'class-validator';
 
-export class GenerateDto {
+import { CHATBOT_ERROR_PROMPT_BLANK } from '@/common/utils/error/error-constants';
+
+class PromptDto {
   @IsString()
-  @IsNotEmpty()
+  @IsNotEmpty({ message: CHATBOT_ERROR_PROMPT_BLANK })
+  @Matches(/\S/, { message: CHATBOT_ERROR_PROMPT_BLANK })
   @ApiProperty({
     example:
-      'I want to learn about artificial intelligence and machine learning'
+      'Je veux apprendre sur l’intelligence artificielle et l’apprentissage automatique',
   })
   public prompt!: string;
+}
+
+export class GenerateDto extends PromptDto {
+  @IsOptional()
+  @IsArray()
+  @IsNumber({}, { each: true })
+  @ApiPropertyOptional({
+    type: [Number],
+    example: [182848],
+    description:
+      'Restrict recommendations to courses belonging to these program IDs'
+  })
+  public programIds?: number[];
+}
+
+export class GenerateStreamDto extends PromptDto {
+  @IsOptional()
+  @IsString()
+  @ApiPropertyOptional({
+    example: '182848',
+    description:
+      'Semicolon-separated program IDs to restrict recommendations to (ex: `182848;183920`) ' +
+      'Sent as a string because EventSource requests carry no JSON body.'
+  })
+  public programIds?: string;
 }
 
 class LlmCourseDto {

--- a/src/llm-generation/dtos/generate.dto.ts
+++ b/src/llm-generation/dtos/generate.dto.ts
@@ -16,7 +16,7 @@ class PromptDto {
   @Matches(/\S/, { message: CHATBOT_ERROR_PROMPT_BLANK })
   @ApiProperty({
     example:
-      'Je veux apprendre sur l’intelligence artificielle et l’apprentissage automatique',
+      'Je veux apprendre sur l’intelligence artificielle et l’apprentissage automatique'
   })
   public prompt!: string;
 }

--- a/src/llm-generation/interfaces/llm-provider.ts
+++ b/src/llm-generation/interfaces/llm-provider.ts
@@ -9,6 +9,14 @@ Do not include any extra text or markdown.
   "explanation": "<brief explanation in the same language as the user's request>"
 }`;
 
+export const STREAM_COURSES_DELIMITER = '###COURSES###';
+
+const STREAM_FORMAT_INSTRUCTION = `
+Respond in plain text, NOT JSON. Match the language of the user's request. Follow this exact structure:
+1. Write a short, friendly explanation (a few sentences of flowing prose, no markdown headers) of the recommended courses.
+2. On its own line, write exactly: ${STREAM_COURSES_DELIMITER}
+3. After that line, output ONLY a JSON array of the recommended course codes, e.g. [{"code":"LOG635"},{"code":"INF130"}], or [] if none. No markdown code blocks, no extra text.`;
+
 export abstract class LlmProvider {
   public readonly name: string;
   public readonly timeoutMs?: number;
@@ -47,10 +55,76 @@ export abstract class LlmProvider {
     return this.parseJsonResponse(this.extractText(data));
   }
 
+  public async *completeStream(
+    prompt: string,
+    signal: AbortSignal
+  ): AsyncGenerator<string> {
+    const fullPrompt = `${prompt}\n${STREAM_FORMAT_INSTRUCTION}`;
+
+    const response = await fetch(this.getUrl(), {
+      method: 'POST',
+      headers: this.getHeaders(),
+      body: JSON.stringify(this.getBody(fullPrompt, true)),
+      signal
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        `${this.name} API error: ${response.status} - ${errorText}`
+      );
+    }
+
+    if (!response.body) {
+      throw new Error(`${this.name} returned no response body for streaming`);
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed.startsWith('data:')) {
+            continue;
+          }
+
+          const data = trimmed.slice('data:'.length).trim();
+          if (data === '[DONE]') {
+            return;
+          }
+
+          try {
+            const delta = this.extractDelta(JSON.parse(data));
+            if (delta) {
+              yield delta;
+            }
+          } catch {
+            // Malformed or partial SSE chunk; skip it.
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
   protected abstract getUrl(): string;
   protected abstract getHeaders(): Record<string, string>;
-  protected abstract getBody(prompt: string): object;
+  protected abstract getBody(prompt: string, stream?: boolean): object;
   protected abstract extractText(data: unknown): string;
+  protected abstract extractDelta(data: unknown): string;
 
   private parseJsonResponse(text: string): LlmGenerationResponse {
     const cleaned = text

--- a/src/llm-generation/interfaces/llm-provider.ts
+++ b/src/llm-generation/interfaces/llm-provider.ts
@@ -79,7 +79,21 @@ export abstract class LlmProvider {
       throw new Error(`${this.name} returned no response body for streaming`);
     }
 
-    const reader = response.body.getReader();
+    for await (const line of this.readSSELines(response.body.getReader())) {
+      const result = this.parseSSELine(line);
+      if (!result) {
+        continue;
+      }
+      if (result.done) {
+        return;
+      }
+      yield result.delta;
+    }
+  }
+
+  private async *readSSELines(
+    reader: ReadableStreamDefaultReader<Uint8Array>
+  ): AsyncGenerator<string> {
     const decoder = new TextDecoder();
     let buffer = '';
 
@@ -93,30 +107,34 @@ export abstract class LlmProvider {
         buffer += decoder.decode(value, { stream: true });
         const lines = buffer.split('\n');
         buffer = lines.pop() ?? '';
-
-        for (const line of lines) {
-          const trimmed = line.trim();
-          if (!trimmed.startsWith('data:')) {
-            continue;
-          }
-
-          const data = trimmed.slice('data:'.length).trim();
-          if (data === '[DONE]') {
-            return;
-          }
-
-          try {
-            const delta = this.extractDelta(JSON.parse(data));
-            if (delta) {
-              yield delta;
-            }
-          } catch {
-            // Malformed or partial SSE chunk; skip it.
-          }
-        }
+        yield* lines;
       }
     } finally {
       reader.releaseLock();
+    }
+  }
+
+  private parseSSELine(
+    line: string
+  ): { done: true; delta?: never } | { done: false; delta: string } | null {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('data:')) {
+      return null;
+    }
+
+    const data = trimmed.slice('data:'.length).trim();
+    if (data === '[DONE]') {
+      return { done: true };
+    }
+
+    try {
+      const delta = this.extractDelta(JSON.parse(data));
+      return delta ? {
+        done: false, delta
+      } : null;
+    } catch {
+      // Malformed or partial SSE chunk; skip it.
+      return null;
     }
   }
 

--- a/src/llm-generation/interfaces/llm-provider.ts
+++ b/src/llm-generation/interfaces/llm-provider.ts
@@ -129,9 +129,12 @@ export abstract class LlmProvider {
 
     try {
       const delta = this.extractDelta(JSON.parse(data));
-      return delta ? {
-        done: false, delta
-      } : null;
+      return delta
+        ? {
+            done: false,
+            delta
+          }
+        : null;
     } catch {
       // Malformed or partial SSE chunk; skip it.
       return null;

--- a/src/llm-generation/llm.controller.ts
+++ b/src/llm-generation/llm.controller.ts
@@ -20,9 +20,23 @@ import { ChatbotEnabledGuard } from '../common/guards/chatbot-enabled.guard';
 import {
   GenerateDto,
   GenerateResponseDto,
+  GenerateStreamDto,
   StatusResponseDto
 } from './dtos/generate.dto';
 import { LlmService } from './llm.service';
+
+function parseProgramIds(raw?: string): number[] | undefined {
+  if (!raw) {
+    return undefined;
+  }
+
+  const ids = raw
+    .split(';')
+    .map((id) => Number(id.trim()))
+    .filter((id) => Number.isFinite(id));
+
+  return ids.length > 0 ? ids : undefined;
+}
 
 @ApiTags('Chatbot')
 @Controller('chatbot')
@@ -47,7 +61,7 @@ export class LlmController {
   public async recommend(
     @Body() body: GenerateDto
   ): Promise<GenerateResponseDto> {
-    return this.llmService.recommend(body.prompt);
+    return this.llmService.recommend(body.prompt, body.programIds);
   }
 
   @Get('recommend/stream')
@@ -63,7 +77,7 @@ export class LlmController {
       'nothing). Test this endpoint with a real EventSource client or curl instead.'
   })
   public async recommendStream(
-    @Query() query: GenerateDto,
+    @Query() query: GenerateStreamDto,
     @Res() response: Response
   ): Promise<void> {
     // Nest's built-in @Sse() decorator hardcodes 'Content-Type: text/event-stream'
@@ -75,7 +89,10 @@ export class LlmController {
     response.setHeader('X-Accel-Buffering', 'no');
     response.flushHeaders();
 
-    const generator = this.llmService.recommendStream(query.prompt);
+    const generator = this.llmService.recommendStream(
+      query.prompt,
+      parseProgramIds(query.programIds)
+    );
     let eventId = 0;
 
     const writeEvent = (type: string, data: unknown) => {

--- a/src/llm-generation/llm.controller.ts
+++ b/src/llm-generation/llm.controller.ts
@@ -3,10 +3,9 @@ import {
   Controller,
   Get,
   HttpCode,
-  MessageEvent,
   Post,
   Query,
-  Sse,
+  Res,
   UseGuards
 } from '@nestjs/common';
 import {
@@ -15,7 +14,7 @@ import {
   ApiProduces,
   ApiTags
 } from '@nestjs/swagger';
-import { Observable } from 'rxjs';
+import type { Response } from 'express';
 
 import { ChatbotEnabledGuard } from '../common/guards/chatbot-enabled.guard';
 import {
@@ -42,7 +41,7 @@ export class LlmController {
   @Post('recommend')
   @HttpCode(200)
   @ApiOperation({
-    summary: 'Generate course recommendations from a natural language prompt'
+    summary: '🟢 Generate course recommendations from a natural language prompt'
   })
   @ApiOkResponse({ type: GenerateResponseDto })
   public async recommend(
@@ -51,34 +50,57 @@ export class LlmController {
     return this.llmService.recommend(body.prompt);
   }
 
-  @Sse('recommend/stream')
+  @Get('recommend/stream')
   @ApiProduces('text/event-stream')
   @ApiOperation({
     summary:
-      'Stream course recommendations from a natural language prompt via Server-Sent Events. ' +
+      '🟢 Stream course recommendations from a natural language prompt via Server-Sent Events. ' +
       'Emits "reason" events with incremental explanation text, followed by a single ' +
-      '"courses" event carrying the final course code list.'
+      '"courses" event carrying the final course code list.',
+    description:
+      'Note: Swagger UI does not natively support Server-Sent Events, so the "Try it out" ' +
+      'button here may not display the streamed response correctly (it may hang or show ' +
+      'nothing). Test this endpoint with a real EventSource client or curl instead.'
   })
-  public recommendStream(@Query() query: GenerateDto): Observable<MessageEvent> {
-    return new Observable<MessageEvent>((subscriber) => {
-      const generator = this.llmService.recommendStream(query.prompt);
+  public async recommendStream(
+    @Query() query: GenerateDto,
+    @Res() response: Response
+  ): Promise<void> {
+    // Nest's built-in @Sse() decorator hardcodes 'Content-Type: text/event-stream'
+    // with no charset, which makes browsers guess (and mangle non-ASCII text).
+    // Streaming manually lets us declare UTF-8 explicitly.
+    response.setHeader('Content-Type', 'text/event-stream; charset=utf-8');
+    response.setHeader('Cache-Control', 'no-cache');
+    response.setHeader('Connection', 'keep-alive');
+    response.setHeader('X-Accel-Buffering', 'no');
+    response.flushHeaders();
 
-      (async () => {
-        try {
-          for await (const event of generator) {
-            subscriber.next({ type: event.type, data: event.data });
-          }
-          subscriber.complete();
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          subscriber.next({ type: 'error', data: message });
-          subscriber.complete();
-        }
-      })();
+    const generator = this.llmService.recommendStream(query.prompt);
+    let eventId = 0;
 
-      return () => {
-        void generator.return?.(undefined);
-      };
+    const writeEvent = (type: string, data: unknown) => {
+      eventId += 1;
+      const payload = typeof data === 'string' ? data : JSON.stringify(data);
+      const dataLines = payload
+        .split(/\r\n|\r|\n/)
+        .map((line) => `data: ${line}`)
+        .join('\n');
+      response.write(`event: ${type}\nid: ${eventId}\n${dataLines}\n\n`);
+    };
+
+    response.req.on('close', () => {
+      void generator.return?.(undefined);
     });
+
+    try {
+      for await (const event of generator) {
+        writeEvent(event.type, event.data);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      writeEvent('error', message);
+    } finally {
+      response.end();
+    }
   }
 }

--- a/src/llm-generation/llm.controller.ts
+++ b/src/llm-generation/llm.controller.ts
@@ -3,10 +3,19 @@ import {
   Controller,
   Get,
   HttpCode,
+  MessageEvent,
   Post,
+  Query,
+  Sse,
   UseGuards
 } from '@nestjs/common';
-import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+  ApiOkResponse,
+  ApiOperation,
+  ApiProduces,
+  ApiTags
+} from '@nestjs/swagger';
+import { Observable } from 'rxjs';
 
 import { ChatbotEnabledGuard } from '../common/guards/chatbot-enabled.guard';
 import {
@@ -40,5 +49,36 @@ export class LlmController {
     @Body() body: GenerateDto
   ): Promise<GenerateResponseDto> {
     return this.llmService.recommend(body.prompt);
+  }
+
+  @Sse('recommend/stream')
+  @ApiProduces('text/event-stream')
+  @ApiOperation({
+    summary:
+      'Stream course recommendations from a natural language prompt via Server-Sent Events. ' +
+      'Emits "reason" events with incremental explanation text, followed by a single ' +
+      '"courses" event carrying the final course code list.'
+  })
+  public recommendStream(@Query() query: GenerateDto): Observable<MessageEvent> {
+    return new Observable<MessageEvent>((subscriber) => {
+      const generator = this.llmService.recommendStream(query.prompt);
+
+      (async () => {
+        try {
+          for await (const event of generator) {
+            subscriber.next({ type: event.type, data: event.data });
+          }
+          subscriber.complete();
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          subscriber.next({ type: 'error', data: message });
+          subscriber.complete();
+        }
+      })();
+
+      return () => {
+        void generator.return?.(undefined);
+      };
+    });
   }
 }

--- a/src/llm-generation/llm.service.ts
+++ b/src/llm-generation/llm.service.ts
@@ -22,6 +22,14 @@ export class LlmService {
   private readonly providers: LlmProvider[];
   private readonly timeoutMs: number;
 
+  private throwExhausted(lastError: Error | undefined): never {
+    this.logger.error(
+      'All LLM providers have been exhausted.',
+      lastError?.message
+    );
+    throw new LlmExhaustedException(lastError);
+  }
+
   private tryProvider(
     model: string | undefined,
     apiKey: string | undefined,
@@ -101,9 +109,18 @@ export class LlmService {
     );
   }
 
-  private async buildEnrichedPrompt(prompt: string): Promise<string> {
-    this.logger.debug(`Retrieving courses for prompt: "${prompt}"`);
-    const courses = await this.courseRetriever.retrieveCourses(prompt);
+  private async buildEnrichedPrompt(
+    prompt: string,
+    programIds?: number[]
+  ): Promise<string> {
+    this.logger.debug(
+      `Retrieving courses for prompt: "${prompt}"` +
+        (programIds?.length ? ` (programIds: ${programIds.join(', ')})` : '')
+    );
+    const courses = await this.courseRetriever.retrieveCourses(
+      prompt,
+      programIds?.length ? { programIds } : undefined
+    );
     this.logger.log(
       `Retrieved ${courses.length} courses:\n` +
         courses
@@ -128,8 +145,11 @@ export class LlmService {
       `;
   }
 
-  public async recommend(prompt: string): Promise<LlmGenerationResponse> {
-    const enrichedPrompt = await this.buildEnrichedPrompt(prompt);
+  public async recommend(
+    prompt: string,
+    programIds?: number[]
+  ): Promise<LlmGenerationResponse> {
+    const enrichedPrompt = await this.buildEnrichedPrompt(prompt, programIds);
 
     let lastError: Error | undefined;
 
@@ -155,15 +175,14 @@ export class LlmService {
       }
     }
 
-    this.logger.error(
-      'All LLM providers have been exhausted.',
-      lastError?.message
-    );
-    throw new LlmExhaustedException(lastError);
+    this.throwExhausted(lastError);
   }
 
-  public async *recommendStream(prompt: string): AsyncGenerator<LlmStreamEvent> {
-    const enrichedPrompt = await this.buildEnrichedPrompt(prompt);
+  public async *recommendStream(
+    prompt: string,
+    programIds?: number[]
+  ): AsyncGenerator<LlmStreamEvent> {
+    const enrichedPrompt = await this.buildEnrichedPrompt(prompt, programIds);
 
     let lastError: Error | undefined;
 
@@ -242,11 +261,7 @@ export class LlmService {
       }
     }
 
-    this.logger.error(
-      'All LLM providers have been exhausted.',
-      lastError?.message
-    );
-    throw new LlmExhaustedException(lastError);
+    this.throwExhausted(lastError);
   }
 
   private parseCourses(text: string, providerName: string): LlmCourse[] {

--- a/src/llm-generation/llm.service.ts
+++ b/src/llm-generation/llm.service.ts
@@ -220,13 +220,7 @@ export class LlmService {
         );
         return;
       } catch (error) {
-        const streamError =
-          error instanceof ProviderStreamError
-            ? error
-            : new ProviderStreamError(
-                error instanceof Error ? error : new Error(String(error)),
-                false
-              );
+        const streamError = this.toProviderStreamError(error);
         lastError = streamError.cause;
         this.logger.warn(
           `Provider ${provider.name} failed: ${lastError.message}`
@@ -281,11 +275,19 @@ export class LlmService {
         data: this.parseCourses(buffer, provider.name)
       };
     } catch (error) {
-      throw new ProviderStreamError(
-        error instanceof Error ? error : new Error(String(error)),
-        yieldedAny
-      );
+      throw this.toProviderStreamError(error, yieldedAny);
     }
+  }
+
+  private toProviderStreamError(
+    error: unknown,
+    yieldedAny = false
+  ): ProviderStreamError {
+    if (error instanceof ProviderStreamError) {
+      return error;
+    }
+    const cause = error instanceof Error ? error : new Error(String(error));
+    return new ProviderStreamError(cause, yieldedAny);
   }
 
   /**

--- a/src/llm-generation/llm.service.ts
+++ b/src/llm-generation/llm.service.ts
@@ -7,7 +7,10 @@ import {
   LlmCourse,
   LlmGenerationResponse
 } from './interfaces/llm-generation-response.interface';
-import { LlmProvider, STREAM_COURSES_DELIMITER } from './interfaces/llm-provider';
+import {
+  LlmProvider,
+  STREAM_COURSES_DELIMITER
+} from './interfaces/llm-provider';
 import { GeminiProvider } from './providers/gemini.provider';
 import { GroqProvider } from './providers/groq.provider';
 import { NvidiaProvider } from './providers/nvidia.provider';
@@ -199,7 +202,9 @@ export class LlmService {
       let sawDelimiter = false;
 
       try {
-        this.logger.debug(`Attempting streaming generation with ${provider.name}`);
+        this.logger.debug(
+          `Attempting streaming generation with ${provider.name}`
+        );
         for await (const chunk of provider.completeStream(
           enrichedPrompt,
           controller.signal
@@ -233,7 +238,9 @@ export class LlmService {
             yieldedAny = true;
             yield { type: 'reason', data: reasonPart };
           }
-          buffer = buffer.slice(delimiterIndex + STREAM_COURSES_DELIMITER.length);
+          buffer = buffer.slice(
+            delimiterIndex + STREAM_COURSES_DELIMITER.length
+          );
           sawDelimiter = true;
         }
 
@@ -244,7 +251,10 @@ export class LlmService {
           buffer = '';
         }
 
-        yield { type: 'courses', data: this.parseCourses(buffer, provider.name) };
+        yield {
+          type: 'courses',
+          data: this.parseCourses(buffer, provider.name)
+        };
         return;
       } catch (error) {
         lastError = error instanceof Error ? error : new Error(String(error));

--- a/src/llm-generation/llm.service.ts
+++ b/src/llm-generation/llm.service.ts
@@ -19,6 +19,19 @@ export type LlmStreamEvent =
   | { type: 'reason'; data: string }
   | { type: 'courses'; data: LlmCourse[] };
 
+/**
+ * Thrown when a provider fails mid-stream. `yieldedAny` tells the caller
+ * whether it's still safe to silently fall back to the next provider.
+ */
+class ProviderStreamError extends Error {
+  constructor(
+    public readonly cause: Error,
+    public readonly yieldedAny: boolean
+  ) {
+    super(cause.message);
+  }
+}
+
 @Injectable()
 export class LlmService {
   private readonly logger = new Logger(LlmService.name);
@@ -195,75 +208,32 @@ export class LlmService {
         () => controller.abort(),
         provider.timeoutMs ?? this.timeoutMs
       );
-      let yieldedAny = false;
-      // Buffer holds text not yet emitted; once past the delimiter it
-      // accumulates the raw (unstreamed) course-list JSON instead.
-      let buffer = '';
-      let sawDelimiter = false;
 
       try {
         this.logger.debug(
           `Attempting streaming generation with ${provider.name}`
         );
-        for await (const chunk of provider.completeStream(
+        yield* this.streamFromProvider(
+          provider,
           enrichedPrompt,
           controller.signal
-        )) {
-          if (sawDelimiter) {
-            buffer += chunk;
-            continue;
-          }
-
-          buffer += chunk;
-          const delimiterIndex = buffer.indexOf(STREAM_COURSES_DELIMITER);
-
-          if (delimiterIndex === -1) {
-            // Hold back enough trailing text that a delimiter split across
-            // chunk boundaries is never emitted as part of the reason.
-            const safeLength = Math.max(
-              0,
-              buffer.length - STREAM_COURSES_DELIMITER.length
-            );
-            if (safeLength > 0) {
-              const toEmit = buffer.slice(0, safeLength);
-              buffer = buffer.slice(safeLength);
-              yieldedAny = true;
-              yield { type: 'reason', data: toEmit };
-            }
-            continue;
-          }
-
-          const reasonPart = buffer.slice(0, delimiterIndex);
-          if (reasonPart) {
-            yieldedAny = true;
-            yield { type: 'reason', data: reasonPart };
-          }
-          buffer = buffer.slice(
-            delimiterIndex + STREAM_COURSES_DELIMITER.length
-          );
-          sawDelimiter = true;
-        }
-
-        if (!sawDelimiter && buffer) {
-          // Model never emitted the delimiter; treat the rest as reason text.
-          yieldedAny = true;
-          yield { type: 'reason', data: buffer };
-          buffer = '';
-        }
-
-        yield {
-          type: 'courses',
-          data: this.parseCourses(buffer, provider.name)
-        };
+        );
         return;
       } catch (error) {
-        lastError = error instanceof Error ? error : new Error(String(error));
+        const streamError =
+          error instanceof ProviderStreamError
+            ? error
+            : new ProviderStreamError(
+                error instanceof Error ? error : new Error(String(error)),
+                false
+              );
+        lastError = streamError.cause;
         this.logger.warn(
           `Provider ${provider.name} failed: ${lastError.message}`
         );
         // Once a provider has started streaming to the client, we can no
         // longer silently fall back to another provider mid-response.
-        if (yieldedAny) {
+        if (streamError.yieldedAny) {
           throw lastError;
         }
       } finally {
@@ -272,6 +242,90 @@ export class LlmService {
     }
 
     this.throwExhausted(lastError);
+  }
+
+  private async *streamFromProvider(
+    provider: LlmProvider,
+    enrichedPrompt: string,
+    signal: AbortSignal
+  ): AsyncGenerator<LlmStreamEvent> {
+    let yieldedAny = false;
+    // Buffer holds text not yet emitted; once past the delimiter it
+    // accumulates the raw (unstreamed) course-list JSON instead.
+    let buffer = '';
+    let sawDelimiter = false;
+
+    try {
+      for await (const chunk of provider.completeStream(
+        enrichedPrompt,
+        signal
+      )) {
+        const result = this.consumeStreamChunk(chunk, buffer, sawDelimiter);
+        buffer = result.buffer;
+        sawDelimiter = result.sawDelimiter;
+        if (result.reason !== undefined) {
+          yieldedAny = true;
+          yield { type: 'reason', data: result.reason };
+        }
+      }
+
+      if (!sawDelimiter && buffer) {
+        // Model never emitted the delimiter; treat the rest as reason text.
+        yieldedAny = true;
+        yield { type: 'reason', data: buffer };
+        buffer = '';
+      }
+
+      yield {
+        type: 'courses',
+        data: this.parseCourses(buffer, provider.name)
+      };
+    } catch (error) {
+      throw new ProviderStreamError(
+        error instanceof Error ? error : new Error(String(error)),
+        yieldedAny
+      );
+    }
+  }
+
+  /**
+   * Folds one streamed chunk into the reason/course-list buffer, holding
+   * back enough trailing text that a delimiter split across chunk
+   * boundaries is never emitted as part of the reason.
+   */
+  private consumeStreamChunk(
+    chunk: string,
+    buffer: string,
+    sawDelimiter: boolean
+  ): { buffer: string; sawDelimiter: boolean; reason?: string } {
+    if (sawDelimiter) {
+      return { buffer: buffer + chunk, sawDelimiter: true };
+    }
+
+    const combined = buffer + chunk;
+    const delimiterIndex = combined.indexOf(STREAM_COURSES_DELIMITER);
+
+    if (delimiterIndex === -1) {
+      const safeLength = Math.max(
+        0,
+        combined.length - STREAM_COURSES_DELIMITER.length
+      );
+      if (safeLength === 0) {
+        return { buffer: combined, sawDelimiter: false };
+      }
+      return {
+        buffer: combined.slice(safeLength),
+        sawDelimiter: false,
+        reason: combined.slice(0, safeLength)
+      };
+    }
+
+    const reasonPart = combined.slice(0, delimiterIndex);
+    return {
+      buffer: combined.slice(delimiterIndex + STREAM_COURSES_DELIMITER.length),
+      sawDelimiter: true,
+      reason: reasonPart || undefined
+    };
   }
 
   private parseCourses(text: string, providerName: string): LlmCourse[] {

--- a/src/llm-generation/llm.service.ts
+++ b/src/llm-generation/llm.service.ts
@@ -3,11 +3,18 @@ import { Injectable, Logger } from '@nestjs/common';
 import { CourseRetrieverService } from '../embedding/course-retriever.service';
 import { ProviderStatusDto } from './dtos/generate.dto';
 import { LlmExhaustedException } from './exceptions/llm-exhausted.exception';
-import { LlmGenerationResponse } from './interfaces/llm-generation-response.interface';
-import { LlmProvider } from './interfaces/llm-provider';
+import {
+  LlmCourse,
+  LlmGenerationResponse
+} from './interfaces/llm-generation-response.interface';
+import { LlmProvider, STREAM_COURSES_DELIMITER } from './interfaces/llm-provider';
 import { GeminiProvider } from './providers/gemini.provider';
 import { GroqProvider } from './providers/groq.provider';
 import { NvidiaProvider } from './providers/nvidia.provider';
+
+export type LlmStreamEvent =
+  | { type: 'reason'; data: string }
+  | { type: 'courses'; data: LlmCourse[] };
 
 @Injectable()
 export class LlmService {
@@ -94,7 +101,7 @@ export class LlmService {
     );
   }
 
-  public async recommend(prompt: string): Promise<LlmGenerationResponse> {
+  private async buildEnrichedPrompt(prompt: string): Promise<string> {
     this.logger.debug(`Retrieving courses for prompt: "${prompt}"`);
     const courses = await this.courseRetriever.retrieveCourses(prompt);
     this.logger.log(
@@ -108,7 +115,7 @@ export class LlmService {
       .map((c) => `- [${c.code}] ${c.title}: ${c.description}`)
       .join('\n');
 
-    const enrichedPrompt = `You are a course recommendation assistant at ÉTS university.
+    return `You are a course recommendation assistant at ÉTS university.
       Match the language of the user's request.
       If the user's question mentions a specific course code, first check whether that course appears in the available courses list. If it does not, say so briefly in the same language as the user's request and return an empty courses array.
       Otherwise, recommend the most relevant courses for the user's request.
@@ -119,6 +126,10 @@ export class LlmService {
       USER REQUEST:
       ${prompt}
       `;
+  }
+
+  public async recommend(prompt: string): Promise<LlmGenerationResponse> {
+    const enrichedPrompt = await this.buildEnrichedPrompt(prompt);
 
     let lastError: Error | undefined;
 
@@ -149,5 +160,114 @@ export class LlmService {
       lastError?.message
     );
     throw new LlmExhaustedException(lastError);
+  }
+
+  public async *recommendStream(prompt: string): AsyncGenerator<LlmStreamEvent> {
+    const enrichedPrompt = await this.buildEnrichedPrompt(prompt);
+
+    let lastError: Error | undefined;
+
+    for (const provider of this.providers) {
+      const controller = new AbortController();
+      const timeout = setTimeout(
+        () => controller.abort(),
+        provider.timeoutMs ?? this.timeoutMs
+      );
+      let yieldedAny = false;
+      // Buffer holds text not yet emitted; once past the delimiter it
+      // accumulates the raw (unstreamed) course-list JSON instead.
+      let buffer = '';
+      let sawDelimiter = false;
+
+      try {
+        this.logger.debug(`Attempting streaming generation with ${provider.name}`);
+        for await (const chunk of provider.completeStream(
+          enrichedPrompt,
+          controller.signal
+        )) {
+          if (sawDelimiter) {
+            buffer += chunk;
+            continue;
+          }
+
+          buffer += chunk;
+          const delimiterIndex = buffer.indexOf(STREAM_COURSES_DELIMITER);
+
+          if (delimiterIndex === -1) {
+            // Hold back enough trailing text that a delimiter split across
+            // chunk boundaries is never emitted as part of the reason.
+            const safeLength = Math.max(
+              0,
+              buffer.length - STREAM_COURSES_DELIMITER.length
+            );
+            if (safeLength > 0) {
+              const toEmit = buffer.slice(0, safeLength);
+              buffer = buffer.slice(safeLength);
+              yieldedAny = true;
+              yield { type: 'reason', data: toEmit };
+            }
+            continue;
+          }
+
+          const reasonPart = buffer.slice(0, delimiterIndex);
+          if (reasonPart) {
+            yieldedAny = true;
+            yield { type: 'reason', data: reasonPart };
+          }
+          buffer = buffer.slice(delimiterIndex + STREAM_COURSES_DELIMITER.length);
+          sawDelimiter = true;
+        }
+
+        if (!sawDelimiter && buffer) {
+          // Model never emitted the delimiter; treat the rest as reason text.
+          yieldedAny = true;
+          yield { type: 'reason', data: buffer };
+          buffer = '';
+        }
+
+        yield { type: 'courses', data: this.parseCourses(buffer, provider.name) };
+        return;
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
+        this.logger.warn(
+          `Provider ${provider.name} failed: ${lastError.message}`
+        );
+        // Once a provider has started streaming to the client, we can no
+        // longer silently fall back to another provider mid-response.
+        if (yieldedAny) {
+          throw lastError;
+        }
+      } finally {
+        clearTimeout(timeout);
+      }
+    }
+
+    this.logger.error(
+      'All LLM providers have been exhausted.',
+      lastError?.message
+    );
+    throw new LlmExhaustedException(lastError);
+  }
+
+  private parseCourses(text: string, providerName: string): LlmCourse[] {
+    const cleaned = text
+      .replace(/^```json\n?/i, '')
+      .replace(/\n?```$/i, '')
+      .trim();
+
+    if (!cleaned) {
+      return [];
+    }
+
+    try {
+      const parsed: unknown = JSON.parse(cleaned);
+      return Array.isArray(parsed) ? (parsed as LlmCourse[]) : [];
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      this.logger.warn(
+        `Failed to parse streamed course list from ${providerName}: ${msg}\nText: ${cleaned}`
+      );
+      return [];
+    }
   }
 }

--- a/src/llm-generation/providers/openai-compatible.provider.ts
+++ b/src/llm-generation/providers/openai-compatible.provider.ts
@@ -17,7 +17,10 @@ export abstract class OpenAiCompatibleProvider extends LlmProvider {
       messages: [{ role: 'user', content: prompt }]
     };
 
-    if (this.useJsonMode) {
+    // JSON mode forces the model to emit a single raw JSON value, which
+    // conflicts with the streaming prompt's "prose, then delimiter, then
+    // JSON" structure, only apply it to the non-streaming path.
+    if (this.useJsonMode && !stream) {
       body['response_format'] = { type: 'json_object' };
     }
 

--- a/src/llm-generation/providers/openai-compatible.provider.ts
+++ b/src/llm-generation/providers/openai-compatible.provider.ts
@@ -10,7 +10,7 @@ export abstract class OpenAiCompatibleProvider extends LlmProvider {
 
   protected readonly useJsonMode: boolean = false;
 
-  protected getBody(prompt: string): object {
+  protected getBody(prompt: string, stream = false): object {
     const body: Record<string, unknown> = {
       model: this.modelName,
       max_tokens: this.maxTokens,
@@ -21,11 +21,20 @@ export abstract class OpenAiCompatibleProvider extends LlmProvider {
       body['response_format'] = { type: 'json_object' };
     }
 
+    if (stream) {
+      body['stream'] = true;
+    }
+
     return body;
   }
 
   protected extractText(data: unknown): string {
     const d = data as { choices?: { message?: { content?: string } }[] };
     return d.choices?.[0]?.message?.content ?? '';
+  }
+
+  protected extractDelta(data: unknown): string {
+    const d = data as { choices?: { delta?: { content?: string } }[] };
+    return d.choices?.[0]?.delta?.content ?? '';
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,9 @@ async function bootstrap() {
     : '1.0.0';
   const swaggerConfig = new DocumentBuilder()
     .setTitle('PlanifETS API')
+    .setDescription(
+      'Built with NestJS. Endpoints marked with 🟢 in their summary are actively consumed by the frontend.'
+    )
     .setExternalDoc('JSON API Documentation', 'docs-json')
     .setVersion(version)
     .build();

--- a/src/program/dtos/id.dto.ts
+++ b/src/program/dtos/id.dto.ts
@@ -3,7 +3,7 @@ import { Type } from 'class-transformer';
 import { IsInt } from 'class-validator';
 
 export class IdDto {
-  @ApiProperty()
+  @ApiProperty({ example: 182848 })
   @Type(() => Number)
   @IsInt()
   public id?: number;

--- a/src/program/program.controller.ts
+++ b/src/program/program.controller.ts
@@ -51,7 +51,7 @@ export class ProgramController {
   }
 
   @Get('list/course/:courseId')
-  @ApiOperation({ summary: 'Get programs list containing the course' })
+  @ApiOperation({ summary: '🟢 Get programs list containing the course' })
   @ApiParam({
     name: 'courseId',
     type: Number,

--- a/src/program/program.controller.ts
+++ b/src/program/program.controller.ts
@@ -15,8 +15,7 @@ import {
 } from '@nestjs/swagger';
 import { Program } from '@prisma/client';
 
-import { IdDto } from '@/common/exceptions/dtos/id.dto';
-
+import { IdDto } from './dtos/id.dto';
 import { ProgramDto, ProgramListDto } from './dtos/program.dto';
 import { ProgramService } from './program.service';
 

--- a/test/common/utils/error/errorUtil.test.ts
+++ b/test/common/utils/error/errorUtil.test.ts
@@ -1,0 +1,46 @@
+import { HttpException } from '@nestjs/common';
+
+import { extractHttpExceptionMessage } from '@/common/utils/error/errorUtil';
+
+describe('extractHttpExceptionMessage', () => {
+  it('returns the response body directly when it is a string', () => {
+    const exception = new HttpException('Not found', 404);
+
+    expect(extractHttpExceptionMessage(exception)).toBe('Not found');
+  });
+
+  it('returns the first message when the response body carries an array of messages', () => {
+    const exception = new HttpException(
+      { statusCode: 400, message: ['prompt should not be empty', 'other'] },
+      400
+    );
+
+    expect(extractHttpExceptionMessage(exception)).toBe(
+      'prompt should not be empty'
+    );
+  });
+
+  it('returns the message when the response body carries a single string message', () => {
+    const exception = new HttpException(
+      { statusCode: 400, message: 'Bad request' },
+      400
+    );
+
+    expect(extractHttpExceptionMessage(exception)).toBe('Bad request');
+  });
+
+  it('falls back to exception.message when the response body has no message', () => {
+    const exception = new HttpException({ statusCode: 500 }, 500);
+
+    expect(extractHttpExceptionMessage(exception)).toBe(exception.message);
+  });
+
+  it('falls back to "Internal Server Error" when nothing else is available', () => {
+    const exception = new HttpException({ statusCode: 500 }, 500);
+    Object.defineProperty(exception, 'message', { value: undefined });
+
+    expect(extractHttpExceptionMessage(exception)).toBe(
+      'Internal Server Error'
+    );
+  });
+});

--- a/test/llm-generation/llm.controller.test.ts
+++ b/test/llm-generation/llm.controller.test.ts
@@ -12,7 +12,8 @@ describe('LlmController', () => {
 
   const llmService = {
     checkStatus: jest.fn(),
-    recommend: jest.fn()
+    recommend: jest.fn(),
+    recommendStream: jest.fn()
   };
 
   async function createApp(chatbotEnabled = true): Promise<void> {
@@ -103,7 +104,10 @@ describe('LlmController', () => {
 
       expect(status).toBe(200);
       expect(body).toEqual(response);
-      expect(llmService.recommend).toHaveBeenCalledWith('I want to learn AI');
+      expect(llmService.recommend).toHaveBeenCalledWith(
+        'I want to learn AI',
+        undefined
+      );
     });
 
     it('returns 400 when the prompt field is missing', async () => {
@@ -160,6 +164,85 @@ describe('LlmController', () => {
 
       expect(status).toBe(404);
       expect(llmService.recommend).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('GET /chatbot/recommend/stream', () => {
+    it('streams reason and courses events as SSE', async () => {
+      await createApp(true);
+
+      // eslint-disable-next-line @typescript-eslint/require-await
+      llmService.recommendStream.mockImplementation(async function* () {
+        yield { type: 'reason', data: 'Hello' };
+        yield { type: 'courses', data: [{ code: 'LOG121' }] };
+      });
+
+      const response = await request(app.getHttpServer())
+        .get('/chatbot/recommend/stream')
+        .query({ prompt: 'I want to learn AI' });
+
+      expect(response.status).toBe(200);
+      expect(response.headers['content-type']).toContain('text/event-stream');
+      expect(response.text).toContain('event: reason');
+      expect(response.text).toContain('data: Hello');
+      expect(response.text).toContain('event: courses');
+      expect(response.text).toContain('data: [{"code":"LOG121"}]');
+    });
+
+    it('parses the semicolon-separated programIds query param before calling the service', async () => {
+      await createApp(true);
+
+      // eslint-disable-next-line @typescript-eslint/require-await
+      llmService.recommendStream.mockImplementation(async function* () {});
+
+      await request(app.getHttpServer())
+        .get('/chatbot/recommend/stream')
+        .query({ prompt: 'AI', programIds: '182848;183920' });
+
+      expect(llmService.recommendStream).toHaveBeenCalledWith(
+        'AI',
+        [182848, 183920]
+      );
+    });
+
+    it('emits an error event when the stream fails mid-flight', async () => {
+      await createApp(true);
+
+      // eslint-disable-next-line @typescript-eslint/require-await
+      llmService.recommendStream.mockImplementation(async function* () {
+        yield { type: 'reason', data: 'partial' };
+        throw new Error('provider exploded');
+      });
+
+      const response = await request(app.getHttpServer())
+        .get('/chatbot/recommend/stream')
+        .query({ prompt: 'I want to learn AI' });
+
+      expect(response.status).toBe(200);
+      expect(response.text).toContain('event: error');
+      expect(response.text).toContain('data: provider exploded');
+    });
+
+    it('returns 400 when the prompt query param is missing', async () => {
+      await createApp(true);
+
+      const { status } = await request(app.getHttpServer()).get(
+        '/chatbot/recommend/stream'
+      );
+
+      expect(status).toBe(400);
+      expect(llmService.recommendStream).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when CHATBOT_ENABLED=false', async () => {
+      await createApp(false);
+
+      const { status } = await request(app.getHttpServer())
+        .get('/chatbot/recommend/stream')
+        .query({ prompt: 'I want to learn AI' });
+
+      expect(status).toBe(404);
+      expect(llmService.recommendStream).not.toHaveBeenCalled();
     });
   });
 });

--- a/test/llm-generation/llm.service.test.ts
+++ b/test/llm-generation/llm.service.test.ts
@@ -3,8 +3,34 @@ import { Logger } from '@nestjs/common';
 import { CourseRetrieverService } from '../../src/embedding/course-retriever.service';
 import { LlmExhaustedException } from '../../src/llm-generation/exceptions/llm-exhausted.exception';
 import { LlmGenerationResponse } from '../../src/llm-generation/interfaces/llm-generation-response.interface';
-import { LlmProvider } from '../../src/llm-generation/interfaces/llm-provider';
-import { LlmService } from '../../src/llm-generation/llm.service';
+import {
+  LlmProvider,
+  STREAM_COURSES_DELIMITER
+} from '../../src/llm-generation/interfaces/llm-provider';
+import {
+  LlmService,
+  LlmStreamEvent
+} from '../../src/llm-generation/llm.service';
+
+async function collect(
+  gen: AsyncGenerator<LlmStreamEvent>
+): Promise<LlmStreamEvent[]> {
+  const events: LlmStreamEvent[] = [];
+  for await (const event of gen) {
+    events.push(event);
+  }
+  return events;
+}
+
+function reasonText(events: LlmStreamEvent[]): string {
+  return events
+    .filter(
+      (e): e is Extract<LlmStreamEvent, { type: 'reason' }> =>
+        e.type === 'reason'
+    )
+    .map((e) => e.data)
+    .join('');
+}
 
 const mockCourseRetriever = {
   retrieveCourses: jest.fn().mockResolvedValue([])
@@ -350,6 +376,183 @@ describe('LlmService', () => {
       );
       expect(capturedSignal?.aborted).toBe(true);
     }, 2000);
+  });
+
+  describe('recommendStream', () => {
+    it('reassembles reason text and yields the parsed courses after the delimiter', async () => {
+      process.env.GROQ_API_KEY = 'groq-key';
+      process.env.GROQ_PRIMARY_MODEL = 'llama-3.3';
+
+      const service = new LlmService(mockCourseRetriever);
+      const [groqProvider] = (
+        service as unknown as { providers: LlmProvider[] }
+      ).providers;
+
+      jest.spyOn(groqProvider, 'completeStream').mockImplementation(
+        // eslint-disable-next-line @typescript-eslint/require-await
+        async function* () {
+          yield 'These courses are great for AI.';
+          yield STREAM_COURSES_DELIMITER;
+          yield JSON.stringify([{ code: 'LOG121' }]);
+        }
+      );
+
+      const events = await collect(
+        service.recommendStream('Suggest AI courses')
+      );
+
+      expect(reasonText(events)).toBe('These courses are great for AI.');
+      expect(events.at(-1)).toEqual({
+        type: 'courses',
+        data: [{ code: 'LOG121' }]
+      });
+    });
+
+    it('never leaks a delimiter split across chunk boundaries into the reason text', async () => {
+      process.env.GROQ_API_KEY = 'groq-key';
+      process.env.GROQ_PRIMARY_MODEL = 'llama-3.3';
+
+      const service = new LlmService(mockCourseRetriever);
+      const [groqProvider] = (
+        service as unknown as { providers: LlmProvider[] }
+      ).providers;
+
+      const half = STREAM_COURSES_DELIMITER.slice(0, 5);
+      const rest = STREAM_COURSES_DELIMITER.slice(5);
+
+      jest.spyOn(groqProvider, 'completeStream').mockImplementation(
+        // eslint-disable-next-line @typescript-eslint/require-await
+        async function* () {
+          yield 'Explanation text';
+          yield half;
+          yield rest;
+          yield '[]';
+        }
+      );
+
+      const events = await collect(
+        service.recommendStream('Suggest AI courses')
+      );
+
+      expect(reasonText(events)).toBe('Explanation text');
+      expect(events.at(-1)).toEqual({ type: 'courses', data: [] });
+    });
+
+    it('falls back to the next provider when the first fails before yielding anything', async () => {
+      process.env.GROQ_API_KEY = 'groq-key';
+      process.env.GROQ_PRIMARY_MODEL = 'llama-3.3';
+      process.env.NVIDIA_API_KEY = 'nvidia-key';
+      process.env.NVIDIA_MODEL = 'nvidia-llama';
+
+      const service = new LlmService(mockCourseRetriever);
+      const [groqProvider, nvidiaProvider] = (
+        service as unknown as { providers: LlmProvider[] }
+      ).providers;
+
+      jest.spyOn(groqProvider, 'completeStream').mockImplementation(
+        // eslint-disable-next-line @typescript-eslint/require-await
+        async function* () {
+          throw new Error('Groq down');
+        }
+      );
+      jest.spyOn(nvidiaProvider, 'completeStream').mockImplementation(
+        // eslint-disable-next-line @typescript-eslint/require-await
+        async function* () {
+          yield 'ok';
+          yield STREAM_COURSES_DELIMITER;
+          yield JSON.stringify([{ code: 'LOG121' }]);
+        }
+      );
+
+      const events = await collect(
+        service.recommendStream('Suggest AI courses')
+      );
+
+      expect(reasonText(events)).toBe('ok');
+      expect(events.at(-1)).toEqual({
+        type: 'courses',
+        data: [{ code: 'LOG121' }]
+      });
+    });
+
+    it('rethrows and does not fall back once the first provider has already streamed reason text', async () => {
+      process.env.GROQ_API_KEY = 'groq-key';
+      process.env.GROQ_PRIMARY_MODEL = 'llama-3.3';
+      process.env.NVIDIA_API_KEY = 'nvidia-key';
+      process.env.NVIDIA_MODEL = 'nvidia-llama';
+
+      const service = new LlmService(mockCourseRetriever);
+      const [groqProvider, nvidiaProvider] = (
+        service as unknown as { providers: LlmProvider[] }
+      ).providers;
+
+      jest.spyOn(groqProvider, 'completeStream').mockImplementation(
+        // eslint-disable-next-line @typescript-eslint/require-await
+        async function* () {
+          yield 'partial reason';
+          throw new Error('stream broke');
+        }
+      );
+      const nvidiaSpy = jest.spyOn(nvidiaProvider, 'completeStream');
+
+      await expect(
+        collect(service.recommendStream('Suggest AI courses'))
+      ).rejects.toThrow('stream broke');
+      expect(nvidiaSpy).not.toHaveBeenCalled();
+    });
+
+    it('throws LlmExhaustedException when every provider fails before yielding', async () => {
+      process.env.GROQ_API_KEY = 'groq-key';
+      process.env.GROQ_PRIMARY_MODEL = 'llama-3.3';
+
+      const service = new LlmService(mockCourseRetriever);
+      const [groqProvider] = (
+        service as unknown as { providers: LlmProvider[] }
+      ).providers;
+
+      jest.spyOn(groqProvider, 'completeStream').mockImplementation(
+        // eslint-disable-next-line @typescript-eslint/require-await
+        async function* () {
+          throw new Error('Groq down');
+        }
+      );
+
+      await expect(
+        collect(service.recommendStream('Suggest AI courses'))
+      ).rejects.toThrow(LlmExhaustedException);
+    });
+
+    it('yields an empty course list and logs a warning when the trailing JSON is malformed', async () => {
+      process.env.GROQ_API_KEY = 'groq-key';
+      process.env.GROQ_PRIMARY_MODEL = 'llama-3.3';
+
+      const service = new LlmService(mockCourseRetriever);
+      const [groqProvider] = (
+        service as unknown as { providers: LlmProvider[] }
+      ).providers;
+
+      jest.spyOn(groqProvider, 'completeStream').mockImplementation(
+        // eslint-disable-next-line @typescript-eslint/require-await
+        async function* () {
+          yield 'reason';
+          yield STREAM_COURSES_DELIMITER;
+          yield 'not json';
+        }
+      );
+
+      const warnSpy = jest
+        .spyOn(Logger.prototype, 'warn')
+        .mockImplementation(() => {});
+
+      const events = await collect(
+        service.recommendStream('Suggest AI courses')
+      );
+
+      expect(events.at(-1)).toEqual({ type: 'courses', data: [] });
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to parse streamed course list')
+      );
+    });
   });
 
   describe('checkStatus', () => {

--- a/test/llm-generation/providers/llm-provider.test.ts
+++ b/test/llm-generation/providers/llm-provider.test.ts
@@ -1,3 +1,4 @@
+import { STREAM_COURSES_DELIMITER } from '../../../src/llm-generation/interfaces/llm-provider';
 import { GeminiProvider } from '../../../src/llm-generation/providers/gemini.provider';
 import { GroqProvider } from '../../../src/llm-generation/providers/groq.provider';
 import { NvidiaProvider } from '../../../src/llm-generation/providers/nvidia.provider';
@@ -17,6 +18,27 @@ const okFetch = (content: string) =>
     ok: true,
     json: async () => ({ choices: [{ message: { content } }] })
   } as Response);
+
+const sseFetch = (lines: string[]) => {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const line of lines) {
+        controller.enqueue(encoder.encode(line));
+      }
+      controller.close();
+    }
+  });
+  return Promise.resolve({ ok: true, body: stream } as unknown as Response);
+};
+
+async function drain(gen: AsyncGenerator<string>): Promise<string[]> {
+  const chunks: string[] = [];
+  for await (const chunk of gen) {
+    chunks.push(chunk);
+  }
+  return chunks;
+}
 
 describe('LLM providers', () => {
   let fetchMock: jest.Mock;
@@ -247,6 +269,106 @@ describe('LLM providers', () => {
       await expect(generatePromise).rejects.toMatchObject({
         name: 'AbortError'
       });
+    });
+  });
+
+  describe('completeStream', () => {
+    it('yields delta content from SSE chunks and stops at [DONE]', async () => {
+      fetchMock.mockReturnValue(
+        sseFetch([
+          `data: ${JSON.stringify({ choices: [{ delta: { content: 'Hello ' } }] })}\n`,
+          `data: ${JSON.stringify({ choices: [{ delta: { content: 'world' } }] })}\n`,
+          `data: [DONE]\n`
+        ])
+      );
+
+      const chunks = await drain(
+        new GroqProvider('llama-3.3', 'key').completeStream(
+          'test',
+          new AbortController().signal
+        )
+      );
+
+      expect(chunks).toEqual(['Hello ', 'world']);
+    });
+
+    it('skips malformed SSE data lines without throwing', async () => {
+      fetchMock.mockReturnValue(
+        sseFetch([
+          `data: not json\n`,
+          `data: ${JSON.stringify({ choices: [{ delta: { content: 'ok' } }] })}\n`,
+          `data: [DONE]\n`
+        ])
+      );
+
+      const chunks = await drain(
+        new GroqProvider('llama-3.3', 'key').completeStream(
+          'test',
+          new AbortController().signal
+        )
+      );
+
+      expect(chunks).toEqual(['ok']);
+    });
+
+    it('throws with status and body when the streaming API returns a non-ok response', async () => {
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: async () => 'server error'
+      } as Response);
+
+      await expect(
+        drain(
+          new GroqProvider('llama-3.3', 'key').completeStream(
+            'test',
+            new AbortController().signal
+          )
+        )
+      ).rejects.toThrow(/500.*server error/);
+    });
+
+    it('throws when the response has no body', async () => {
+      fetchMock.mockResolvedValue({ ok: true, body: null } as Response);
+
+      await expect(
+        drain(
+          new GroqProvider('llama-3.3', 'key').completeStream(
+            'test',
+            new AbortController().signal
+          )
+        )
+      ).rejects.toThrow(/no response body for streaming/);
+    });
+
+    it('sets stream:true and omits response_format in the request body, even for JSON-mode providers', async () => {
+      fetchMock.mockReturnValue(sseFetch([`data: [DONE]\n`]));
+
+      await drain(
+        new GroqProvider('llama-3.3', 'key').completeStream(
+          'test',
+          new AbortController().signal
+        )
+      );
+
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(body.stream).toBe(true);
+      expect(body.response_format).toBeUndefined();
+    });
+
+    it('appends the streaming format instructions and delimiter to the prompt', async () => {
+      fetchMock.mockReturnValue(sseFetch([`data: [DONE]\n`]));
+
+      await drain(
+        new GroqProvider('llama-3.3', 'key').completeStream(
+          'my prompt',
+          new AbortController().signal
+        )
+      );
+
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(body.messages[0].content).toContain('my prompt');
+      expect(body.messages[0].content).toContain(STREAM_COURSES_DELIMITER);
     });
   });
 

--- a/test/program/program.service.integration.test.ts
+++ b/test/program/program.service.integration.test.ts
@@ -29,7 +29,7 @@ describe('ProgramService (integration)', () => {
 
     // Seed baseline data once with the non-transaction client.
     await programsJobService.processPrograms();
-  });
+  }, 60000);
 
   afterAll(async () => {
     if (seedModule) {


### PR DESCRIPTION
### ⁉️ Related Issue
<!-- Link the issue this PR addresses, e.g. "Closes #123". Write N/A if none. -->
closes #130 
closes #136 

## 📖 Description
<!-- Describe what this PR changes and why. -->
- Streams course recommendations over SSE at `GET /chatbot/recommend/stream`, emitting incremental `reason` text events followed by a final `courses` event, with the same multi-provider fallback used by `POST /chatbot/recommend`.
- Adds `extractHttpExceptionMessage` so `HttpExceptionFilter` surfaces the actual validation/exception message instead of always falling back to a generic one.

### 🧪 How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes. -->
unit tests

### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

### 🖼️ Screenshots (if useful)
<!-- Add screenshots or screen recordings if they help reviewers. -->
