### PR TITLE
fix: include Prisma schema engine in production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,7 @@ COPY package.json ./
 COPY --from=build /app/dist ./dist
 COPY --from=prod-deps /app/node_modules ./node_modules
 COPY --from=build /app/node_modules/.prisma ./node_modules/.prisma
+COPY --from=build /app/node_modules/@prisma/engines ./node_modules/@prisma/engines
 COPY prisma ./prisma
 
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Closes #142. Includes the Prisma schema engine in the production image so prisma migrate deploy can run before application startup. Tested with yarn build and git diff --check. The Docker image build is left to CI because Docker Desktop is not running locally.