### PR TITLE
Fix/auto hash fetch on deploy tag

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - 'v*'
+      - "v*"
   pull_request:
     branches:
       - main
@@ -20,8 +20,8 @@ on:
           - dev
           - prod
       source_tag:
-        description: Immutable GHCR tag to promote (for example main-a1b2c3d)
-        required: true
+        description: Immutable GHCR tag to promote (for example main-a1b2c3d). Defaults to the latest main commit.
+        required: false
         type: string
 
 env:
@@ -43,8 +43,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22.x
-          cache: 'yarn'
-          cache-dependency-path: 'yarn.lock'
+          cache: "yarn"
+          cache-dependency-path: "yarn.lock"
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --ignore-scripts
@@ -107,6 +107,21 @@ jobs:
     permissions:
       packages: write
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Resolve source tag
+        id: resolve-tag
+        shell: bash
+        run: |
+          if [[ -n "${{ inputs.source_tag }}" ]]; then
+            echo "SOURCE_TAG=${{ inputs.source_tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "SOURCE_TAG=main-$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -120,7 +135,7 @@ jobs:
       - name: Promote immutable image
         shell: bash
         env:
-          SOURCE_TAG: ${{ inputs.source_tag }}
+          SOURCE_TAG: ${{ steps.resolve-tag.outputs.SOURCE_TAG }}
           TARGET_ENVIRONMENT: ${{ inputs.environment }}
         run: |
           set -euo pipefail

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -111,10 +111,11 @@ jobs:
         id: resolve-tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_SOURCE_TAG: ${{ inputs.source_tag }}
         shell: bash
         run: |
-          if [[ -n "${{ inputs.source_tag }}" ]]; then
-            echo "SOURCE_TAG=${{ inputs.source_tag }}" >> "$GITHUB_OUTPUT"
+          if [[ -n "${INPUT_SOURCE_TAG}" ]]; then
+            echo "SOURCE_TAG=${INPUT_SOURCE_TAG}" >> "$GITHUB_OUTPUT"
           else
             package="${GITHUB_REPOSITORY,,}"
             package="${package#*/}"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -107,19 +107,31 @@ jobs:
     permissions:
       packages: write
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: main
-
       - name: Resolve source tag
         id: resolve-tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
           if [[ -n "${{ inputs.source_tag }}" ]]; then
             echo "SOURCE_TAG=${{ inputs.source_tag }}" >> "$GITHUB_OUTPUT"
           else
-            echo "SOURCE_TAG=main-$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
+            package="${GITHUB_REPOSITORY,,}"
+            package="${package#*/}"
+            owner="${GITHUB_REPOSITORY_OWNER}"
+
+            if gh api "/orgs/${owner}/packages/container/${package}/versions" > /dev/null 2>&1; then
+              endpoint="/orgs/${owner}/packages/container/${package}/versions"
+            else
+              endpoint="/users/${owner}/packages/container/${package}/versions"
+            fi
+
+            latest=$(gh api --paginate \
+              -H "Accept: application/vnd.github+json" \
+              "${endpoint}" \
+              | jq -r '[.[] | select(.metadata.container.tags | map(startswith("main-")) | any)] | sort_by(.updated_at) | last | .metadata.container.tags[] | select(startswith("main-"))')
+
+            echo "SOURCE_TAG=${latest}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
### ⁉️ Related Issue
N/A

## 📖 Description
Improves the `promote` job in the CD workflow so that `source_tag` no longer needs
to be provided manually when deploying.

Previously, `source_tag` was a required input and the operator had to look up and
copy the exact `main-<sha>` tag. The job now:
- Makes `source_tag` optional.
- When omitted, queries the GitHub Container Registry API via the `gh` CLI to find
  the most recently pushed `main-*` image (sorted by `updated_at`), which correctly
  reflects the last successful `docker` job rather than the latest git commit.
- Removes the `Checkout code` step from `promote` since it is no longer needed.

### 🧪 How Has This Been Tested?
Manually triggered the `promote` workflow without a `source_tag` and verified the
correct `main-<sha>` tag was resolved and re-tagged.

### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.